### PR TITLE
Added ability to specify wildcards in file_name for #translate_from_file

### DIFF
--- a/lib/route_translator/route_set.rb
+++ b/lib/route_translator/route_set.rb
@@ -25,7 +25,10 @@ module RouteTranslator
     #Use the translations from the specified file
     def translate_from_file(file_path = nil)
       file_path ||= defined?(Rails) && File.join(Rails.root, %w(config i18n-routes.yml))
-      load_dictionary_from_file(file_path)
+      reset_dictionary
+      Dir[file_path].each do |file|
+        add_dictionary_from_file(file)
+      end
       translate
     end
 


### PR DESCRIPTION
Allows to split the translations into separate files and then include them all at once like this:

```
MyApp::Application.routes.translate_from_file(Rails.root.join('config', 'locales', "routes.*.yml"))
```
