### PR TITLE
Added ability to translate whole paths

### DIFF
--- a/lib/route_translator/route_set/translator.rb
+++ b/lib/route_translator/route_set/translator.rb
@@ -104,7 +104,8 @@ module RouteTranslator
       # Translates a path and adds the locale prefix.
       def translate_path(path, locale)
         final_optional_segments = path.slice!(/(\(.+\))$/)
-        new_path = path.split("/").map{|seg| translate_path_segment(seg, locale)}.join('/')
+        new_path = translate_string(path, locale)
+        new_path ||= path.split("/").map{ |seg| translate_path_segment(seg, locale) }.join('/')
         new_path = "/#{locale.downcase}#{new_path}" unless default_locale?(locale)
         new_path = "/" if new_path.blank?
         "#{new_path}#{final_optional_segments}"


### PR DESCRIPTION
See https://github.com/enriclluelles/route_translator/issues/1

The translations can now include whole paths like this:

```
de:
  '/consulting': '/beratungsanfrage'
  '/consulting/new': '/beratungsanfrage'
  '/couples/sample': '/musterseite'
  '/couples/:couple_id/pages/:id': '/hochzeitsreise~:couple_id~:id'
```

This way the routes.rb itself stays completely clean of any translations and custom routes. Also tools like wti can be used to edit/ update the translations, which would not be possible if hardcoding them in routes.rb.
