### PR TITLE
Always generates original untranslated route.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,12 @@ end
 
 ### Available Configurations
 
-* **force_locale** - Set this options to `true` to force the locale to be added
-to all generated route paths, even for the default locale. Defaults to `false`
+* **force_locale** - Set this options to `true` to force the locale to be
+  added to all generated route paths, even for the default locale.
+  Defaults to `false`.
+* **generate_unlocalized_routes** - Set this option to `true` to add
+  translated routes without deleting original unlocalized versions.
+  Autosets `force_locale=true`. Defaults to `false`.
 
 Contributing
 ------------

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -17,7 +17,7 @@ module RouteTranslator
     ActionDispatch::Routing::UrlFor
   ].freeze
 
-  Configuration = Struct.new(:force_locale)
+  Configuration = Struct.new(:force_locale, :generate_unlocalized_routes)
 
   def self.locale_suffix locale
     locale.to_s.underscore

--- a/lib/route_translator/railtie.rb
+++ b/lib/route_translator/railtie.rb
@@ -5,6 +5,7 @@ module RouteTranslator
     initializer "route_translator.set_configs" do |app|
       options = app.config.route_translator
       options.force_locale ||= false
+      options.generate_unlocalized_routes ||= false
 
       ActiveSupport.on_load :route_translator do
         options.each do |k, v|

--- a/test/route_translator_test.rb
+++ b/test/route_translator_test.rb
@@ -17,8 +17,12 @@ class TranslateRoutesTest < ActionController::TestCase
     I18n.default_locale = locale
   end
 
-  def config_force_locale (force)
-    RouteTranslator.config.force_locale = force
+  def config_force_locale(boolean)
+    RouteTranslator.config.force_locale = boolean
+  end
+
+  def config_generate_unlocalized_routes(boolean)
+    RouteTranslator.config.generate_unlocalized_routes = boolean
   end
 
   def setup
@@ -28,7 +32,8 @@ class TranslateRoutesTest < ActionController::TestCase
   end
 
   def teardown
-    config_force_locale(false)
+    config_force_locale false
+    config_generate_unlocalized_routes false
   end
 
   def test_unnamed_root_route
@@ -335,6 +340,22 @@ class TranslateRoutesTest < ActionController::TestCase
 
     assert_routing '/en/people', :controller => 'people', :action => 'index', :locale => 'en'
     assert_unrecognized_route '/people', :controller => 'people', :action => 'index'
+  end
+
+  def test_generate_unlocalized_routes
+    @routes.draw do
+      localized do
+        match 'people', :to => 'people#index', :as => 'people'
+      end
+    end
+
+    config_default_locale_settings 'en'
+    config_generate_unlocalized_routes true
+
+    @routes.translate_from_file(File.expand_path('locales/routes.yml', File.dirname(__FILE__)))
+
+    assert_routing '/en/people', :controller => 'people', :action => 'index', :locale => 'en'
+    assert_routing '/people', :controller => 'people', :action => 'index'
   end
 
   def test_action_controller_gets_locale_setter


### PR DESCRIPTION
Before:

```
 car_en GET /cars/:id(.:format)     cars#show {:locale=>"en"}
 car_es GET /es/autos/:id(.:format) cars#show {:locale=>"es"}
```

After:

```
 car_en GET /en/cars/:id(.:format)  cars#show {:locale=>"en"}
 car_es GET /es/autos/:id(.:format) cars#show {:locale=>"es"}
 car    GET /cars/:id(.:format)
```
