### PR TITLE
Translate the routes automatically.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ SampleApp/tmp/**/*
 SampleApp/db/test.sqlite3
 /.rvmrc
 /Gemfile.lock
+test/log
+test/tmp

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "http://rubygems.org"
 gemspec
 
 gem "rails", "~> 3.2.6"
+gem "rb-fsevent", :require => false if RUBY_PLATFORM =~ /darwin/i

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,8 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+guard :test do
+  watch(%r{^lib/(.+)\.rb$})     { |m| "test/route_translator_test.rb" }
+  watch(%r{^test/.+_test\.rb$})
+  watch('test/test_helper.rb')  { "test" }
+end

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ end
 * **force_locale** - Set this options to `true` to force the locale to be added
 to all generated route paths, even for the default locale. Defaults to `false`
 
+* **translation_file** - Sets the translation file(s) used for translating the
+routes. Defaults to `config/i18n-routes.yml`
+
 Contributing
 ------------
 

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -4,6 +4,7 @@ require 'action_mailer'
 require 'action_dispatch'
 
 require 'route_translator/route_set'
+require 'route_translator/routes_reloader'
 require 'route_translator/railtie' if defined?(Rails::Railtie)
 
 module RouteTranslator
@@ -17,7 +18,7 @@ module RouteTranslator
     ActionDispatch::Routing::UrlFor
   ].freeze
 
-  Configuration = Struct.new(:force_locale)
+  Configuration = Struct.new(:force_locale, :translation_file)
 
   def self.locale_suffix locale
     locale.to_s.underscore

--- a/lib/route_translator/railtie.rb
+++ b/lib/route_translator/railtie.rb
@@ -5,6 +5,7 @@ module RouteTranslator
     initializer "route_translator.set_configs" do |app|
       options = app.config.route_translator
       options.force_locale ||= false
+      options.translation_file ||= File.join(%w[config i18n-routes.yml])
 
       ActiveSupport.on_load :route_translator do
         options.each do |k, v|

--- a/lib/route_translator/route_set.rb
+++ b/lib/route_translator/route_set.rb
@@ -24,13 +24,24 @@ module RouteTranslator
 
     #Use the translations from the specified file
     def translate_from_file(file_path = nil)
-      file_path ||= defined?(Rails) && File.join(Rails.root, %w(config i18n-routes.yml))
+      file_path = absolute_path(file_path)
+
       reset_dictionary
       Dir[file_path].each do |file|
         add_dictionary_from_file(file)
       end
       translate
     end
+
+private
+
+    def absolute_path (file_path)
+      file_path ||= RouteTranslator.config.translation_file
+      file_path = Rails.root.join(file_path) if defined?(Rails)
+      file_path
+    end
+
+public
 
     include Helpers
     include Translator

--- a/lib/route_translator/routes_reloader.rb
+++ b/lib/route_translator/routes_reloader.rb
@@ -1,0 +1,20 @@
+require "rails"
+
+module Rails
+  class Application
+    class RoutesReloader
+      alias :__reload__! :reload!
+
+      def reload!
+        result = __reload__!
+
+        route_sets.each do |routes|
+          routes.default_locale = I18n.default_locale
+          routes.translate_from_file
+        end
+
+        result
+      end
+    end
+  end
+end

--- a/lib/route_translator/test_request.rb
+++ b/lib/route_translator/test_request.rb
@@ -1,0 +1,12 @@
+module ActionDispatch
+  class TestRequest < Request
+    def initialize(env = {})
+      env = Rails.application.env_config.merge(env) if defined?(Rails.application) && Rails.application
+      super(DEFAULT_ENV.merge(env))
+
+      self.host        = 'test.host'
+      self.remote_addr = '0.0.0.0'
+      self.user_agent  = 'Rails Testing'
+    end
+  end
+end

--- a/route_translator.gemspec
+++ b/route_translator.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency("mocha")
+  s.add_development_dependency("guard-test")
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+require 'rails/application/route_inspector'
+
 class StubbedI18nBackend
   @@translations = {
     'es' => { 'people' => 'gente'},
@@ -13,8 +15,6 @@ class StubbedI18nBackend
   def self.available_locales
     @@translations.keys
   end
-
-
 end
 
 module RouteTranslator
@@ -30,6 +30,46 @@ module RouteTranslator
 
     def formatted_root_route?
       !(defined?(ActionPack) && ActionPack::VERSION::MAJOR == 3 && ActionPack::VERSION::MINOR > 0)
+    end
+
+    def setup_application
+      return if defined?(@@app)
+
+      app = Class.new(Rails::Application)
+      app.config.active_support.deprecation = :stderr
+      app.paths["log"] = "#{tmp_path}/log/test.log"
+      app.paths["config/routes"] = File.join(app_path, routes_config)
+      app.initialize!
+      @@app = Rails.application = app
+    end
+
+    def app
+      @@app
+    end
+
+    def tmp_path(*args)
+      @tmp_path ||= File.join(File.dirname(__FILE__), "tmp")
+      File.join(@tmp_path, *args)
+    end
+
+    def app_path(*args)
+      tmp_path(*%w[app] + args)
+    end
+
+    def app_file(path, contents)
+      FileUtils.mkdir_p File.dirname("#{app_path}/#{path}")
+      File.open("#{app_path}/#{path}", 'w') do |f|
+        f.puts contents
+      end
+    end
+
+    def routes_config
+      @@routes_config ||= File.join("config", "routes.rb")
+    end
+
+    def print_routes (route_set)
+      inspector = Rails::Application::RouteInspector.new
+      puts inspector.format(route_set.routes, ENV['CONTROLLER']).join "\n"
     end
 
     def assert_helpers_include(*helpers)


### PR DESCRIPTION
This change makes the call to `MyApp::Application.routes.translate_from_file` unnecessary. It's still possible to call this function for backwards compatibility.

It also adds a new config option, `translation_file`, which can be used instead of the call to `translate_from_file` to change the default translation file.

I also took the liberty of adding `guard` to automatically running the tests.
