### PR TITLE
Fix a conflict with the "routing-filter" gem.

### DIFF
--- a/lib/route_translator/route_set/translator.rb
+++ b/lib/route_translator/route_set/translator.rb
@@ -9,6 +9,8 @@ module RouteTranslator
         # save original routes and clear route set
         original_routes = routes.dup
         original_named_routes = named_routes.routes.dup  # Hash {:name => :route}
+
+        # The filter method exists if the "routing-filter" gem is used
         original_filters = set.respond_to?(:filters) ? set.filters.dup : []
 
         routes_to_create = []


### PR DESCRIPTION
There's a conflict with the `routing-filter` gem which this pull request fixes. I don't know what's most appropriate way to handle these kind of issues but it was a simple code change.

The problem is that `route-translator` resets the routes which will clear the filters used by `routing-filter`. This fix restores the filters after the reset.

I have not added a test for this, don't know if that is possible.
