### PR TITLE
translation_file option removal from config

### DIFF
--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -10,7 +10,7 @@ module RouteTranslator
 
   TRANSLATABLE_SEGMENT = /^([-_a-zA-Z0-9]+)(\()?/.freeze
 
-  Configuration = Struct.new(:force_locale, :generate_unlocalized_routes, :translation_file, :locale_param_key, :generate_unnamed_unlocalized_routes)
+  Configuration = Struct.new(:force_locale, :generate_unlocalized_routes, :locale_param_key, :generate_unnamed_unlocalized_routes)
 
   def self.config(&block)
     @config ||= Configuration.new


### PR DESCRIPTION
As the translation_file option is no longer being used it should be removed from the `Configuration = Struct` under `route_translator.rb` to minimize confusion.

We were using this and realised the `.yml` file in a different location was no longer loaded as before.
