### PR TITLE
Generate correct route when :format segment is mandatory (fixing #57)

### DIFF
--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -54,7 +54,7 @@ module RouteTranslator
     def self.translate_path(path, locale)
       new_path = path.dup
       final_optional_segments = new_path.slice!(/(\([^\/]+\))$/)
-      translated_segments = new_path.split("/").map{ |seg| translate_path_segment(seg, locale) }.select{ |seg| !seg.blank? }
+      translated_segments = new_path.split(/\/|\./).map{ |seg| translate_path_segment(seg, locale) }.select{ |seg| !seg.blank? }
 
       # if not hiding locale then
       # add locale prefix if it's not the default locale,
@@ -66,7 +66,12 @@ module RouteTranslator
         end
       end
 
-      "/#{translated_segments.join('/')}#{final_optional_segments}".gsub(/\/\(\//, '(/')
+      joined_segments = translated_segments.inject do |memo, segment|
+        separator = segment == ':format' ? '.' : '/'
+        memo << separator << segment
+      end
+
+      "/#{joined_segments}#{final_optional_segments}".gsub(/\/\(\//, '(/')
     end
 
     def self.translate_name(n, locale)

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -285,6 +285,30 @@ class TranslateRoutesTest < ActionController::TestCase
     end
   end
 
+  def test_route_with_mandatory_format
+    draw_routes do
+      localized do
+        get 'people.:format', :to => 'people#index'
+      end
+    end
+
+    assert_routing '/es/gente.xml', :controller => 'people', :action => 'index', :format => 'xml', :locale => 'es'
+    assert_routing '/people.xml', :controller => 'people', :action => 'index', :format => 'xml', :locale => 'en'
+  end
+
+  def test_route_with_optional_format
+    draw_routes do
+      localized do
+        get 'people(.:format)', :to => 'people#index'
+      end
+    end
+
+    assert_routing '/es/gente', :controller => 'people', :action => 'index', :locale => 'es'
+    assert_routing '/people', :controller => 'people', :action => 'index', :locale => 'en'
+    assert_routing '/es/gente.xml', :controller => 'people', :action => 'index', :format => 'xml', :locale => 'es'
+    assert_routing '/people.xml', :controller => 'people', :action => 'index', :format => 'xml', :locale => 'en'
+  end
+
   def test_i18n_based_translations_setting_locales
     config_default_locale_settings 'en'
 


### PR DESCRIPTION
The issue was that in `get 'people.:format'` the format segment is separated by `.`. not `/`.

Fixing https://github.com/enriclluelles/route_translator/issues/57.

But my fix only works for `.:format` segment. It will not work for other segment separated by dot! e.g. `/people.:something`.
