### PR TITLE
add option to set locale based on tld of host domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,26 @@ end
   Defaults to `false`.
 * **locale_param_key** - The param key that will be used to set the
   locale to the newly generated routes. Defaults to :locale
+* **tld_locales** - a hash mapping domain tlds to locales, eg  
+  `{:'co.uk' => :en, :de => :de }` 
+  This allows multi-domain applications to set the native locale dynamically
+  based on the TLD of the domain, and hide that locale from routes, acting like a
+  dynamic `hide_locale`.  
+
+  This also affects path_helpers, see example: 
+  ```ruby
+  # host: your_app.co.uk
+  users_path              #=> '/users'
+  users_path(locale: :en) #=> '/users'
+  users_path(locale: :de) #=> '/de/benutzer'
+  # host: your_app.de
+  users_path              #=> '/benutzer'
+  users_path(locale: :en) #=> '/en/users'
+  users_path(locale: :de) #=> '/benutzer'
+  ```
+
+  This option supercedes and ignores all the other options and should be
+  considered an alternative use-case for this gem.
 
 Contributing
 ------------

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -10,21 +10,39 @@ module RouteTranslator
 
   TRANSLATABLE_SEGMENT = /^([-_a-zA-Z0-9]+)(\()?/.freeze
 
-  Configuration = Struct.new(:force_locale, :hide_locale, :generate_unlocalized_routes, :locale_param_key, :generate_unnamed_unlocalized_routes)
+  Configuration = Struct.new(:force_locale, :hide_locale,
+                             :generate_unlocalized_routes, :locale_param_key,
+                             :generate_unnamed_unlocalized_routes,
+                             :tld_locales)
 
   def self.config(&block)
-    @config ||= Configuration.new
-    @config.force_locale ||= false
-    @config.hide_locale ||= false
-    @config.generate_unlocalized_routes ||= false
-    @config.locale_param_key ||= :locale
+    @config                                     ||= Configuration.new
+    @config.force_locale                        ||= false
+    @config.hide_locale                         ||= false
+    @config.generate_unlocalized_routes         ||= false
+    @config.locale_param_key                    ||= :locale
     @config.generate_unnamed_unlocalized_routes ||= false
+    @config.tld_locales                         ||= {}.with_indifferent_access
     yield @config if block
+    resolve_config_conflicts
     @config
+  end
+
+  def self.resolve_config_conflicts
+    if @config.tld_locales.present?
+      @config.generate_unlocalized_routes, @config.generate_unnamed_unlocalized_routes = false, false
+    end
+  end
+
+  def self.native_locale?(locale)
+    !!locale.match(/native_/)
+  end
+
+  def self.native_locales
+    config.tld_locales.values.map{|locale| :"native_#{locale}" }
   end
 
   def self.locale_param_key
     self.config.locale_param_key
   end
-
 end

--- a/lib/route_translator/extensions/action_controller.rb
+++ b/lib/route_translator/extensions/action_controller.rb
@@ -2,10 +2,27 @@ require 'action_controller'
 
 module ActionController
   class Base
+    before_filter :set_default_locale_from_tld, if: -> { RouteTranslator.config.tld_locales[tld] }
     around_filter :set_locale_from_url
+    helper_method :locale_from_tld, :tld
 
+    private
     def set_locale_from_url(&block)
-      I18n.with_locale params[RouteTranslator.locale_param_key], &block
+      I18n.with_locale(params[RouteTranslator.locale_param_key], &block)
+    end
+
+    def set_default_locale_from_tld
+      I18n.default_locale = locale_from_tld || I18n.default_locale
+      I18n.locale         = locale_from_tld || I18n.locale
+    end
+
+    def locale_from_tld
+      locale = RouteTranslator.config.tld_locales[tld].try(:to_sym)
+      I18n.available_locales.include?(locale) ? locale : nil
+    end
+
+    def tld
+      tld = request.host.split('.', 2).last.to_sym
     end
   end
 end

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -13,31 +13,31 @@ module RouteTranslator
 
         helper_container.__send__(:define_method, new_helper_name) do |*args|
           locale_suffix = I18n.locale.to_s.underscore
-          if respond_to?("#{old_name}_#{locale_suffix}_#{suffix}")
+          if RouteTranslator.config.tld_locales && RouteTranslator.config.tld_locales[self.try(:tld)]
+            if args.empty? || (args.select{|e| e.is_a?(Hash) }.first[:locale] == I18n.default_locale)
+            __send__("#{old_name}_native_#{self.try(:locale_from_tld)}_#{suffix}", *args)
+            else
+            __send__("#{old_name}_#{args.first[:locale]}_#{suffix}", *args)
+            end
+          elsif respond_to?("#{old_name}_#{locale_suffix}_#{suffix}")
             __send__("#{old_name}_#{locale_suffix}_#{suffix}", *args)
           else
             __send__("#{old_name}_#{I18n.default_locale.to_s.underscore}_#{suffix}", *args)
           end
         end
-
       end
     end
 
     def self.translations_for(app, conditions, requirements, defaults, route_name, anchor, route_set, &block)
       add_untranslated_helpers_to_controllers_and_views(route_name, route_set.named_routes.module, route_set.named_routes.helpers)
-      # Make sure the default locale is translated in last place to avoid
-      # problems with wildcards when default locale is omitted in paths. The
-      # default routes will catch all paths like wildcard if it is translated first
-      available_locales = I18n.available_locales.dup
-      available_locales.delete I18n.default_locale
-      available_locales.push I18n.default_locale
+
       available_locales.each do |locale|
         new_conditions = conditions.dup
         new_conditions[:path_info] = translate_path(conditions[:path_info], locale)
         if new_conditions[:required_defaults] && !new_conditions[:required_defaults].include?(RouteTranslator.locale_param_key)
           new_conditions[:required_defaults] << RouteTranslator.locale_param_key if new_conditions[:required_defaults]
         end
-        new_defaults = defaults.merge(RouteTranslator.locale_param_key => locale.to_s)
+        new_defaults = defaults.merge(RouteTranslator.locale_param_key => locale.to_s.gsub('native_', ''))
         new_requirements = requirements.merge(RouteTranslator.locale_param_key => locale.to_s)
         new_route_name = translate_name(route_name, locale)
         new_route_name = nil if new_route_name && route_set.named_routes.routes[new_route_name.to_sym] #TODO: Investigate this :(
@@ -50,23 +50,35 @@ module RouteTranslator
       end
     end
 
+    private
+    def self.available_locales
+      available_locales = I18n.available_locales.dup
+      available_locales.push *RouteTranslator.native_locales if RouteTranslator.native_locales.present?
+      # Make sure the default locale is translated in last place to avoid
+      # problems with wildcards when default locale is omitted in paths. The
+      # default routes will catch all paths like wildcard if it is translated first.
+      available_locales.push(available_locales.delete(I18n.default_locale))
+    end
+
     # Translates a path and adds the locale prefix.
     def self.translate_path(path, locale)
       new_path = path.dup
       final_optional_segments = new_path.slice!(/(\([^\/]+\))$/)
       translated_segments = new_path.split("/").map{ |seg| translate_path_segment(seg, locale) }.select{ |seg| !seg.blank? }
 
-      # if not hiding locale then
-      # add locale prefix if it's not the default locale,
-      # or forcing locale to all routes,
-      # or already generating actual unlocalized routes
-      if !RouteTranslator.config.hide_locale && (!default_locale?(locale) || RouteTranslator.config.force_locale || RouteTranslator.config.generate_unlocalized_routes || RouteTranslator.config.generate_unnamed_unlocalized_routes)
-        if !locale_param_present?(new_path)
-          translated_segments.unshift locale.to_s.downcase
-        end
+      if display_locale?(locale) && !locale_param_present?(new_path)
+        translated_segments.unshift(locale.to_s.downcase)
       end
 
       "/#{translated_segments.join('/')}#{final_optional_segments}".gsub(/\/\(\//, '(/')
+    end
+
+    def self.display_locale?(locale)
+      !RouteTranslator.config.hide_locale && !RouteTranslator.native_locale?(locale) &&
+        (!default_locale?(locale) ||
+         RouteTranslator.config.force_locale ||
+         RouteTranslator.config.generate_unlocalized_routes ||
+         RouteTranslator.config.generate_unnamed_unlocalized_routes)
     end
 
     def self.translate_name(n, locale)
@@ -82,7 +94,7 @@ module RouteTranslator
     # "people" will be translated, if there is no translation, the path
     # segment is blank, begins with a ":" (param key) or "*" (wildcard),
     # the segment is returned untouched
-    def self.translate_path_segment segment, locale
+    def self.translate_path_segment(segment, locale)
       return segment if segment.blank? or segment.starts_with?(":") or segment.starts_with?("(") or segment.starts_with?("*")
 
       appended_part = segment.slice!(/(\()$/)
@@ -92,6 +104,7 @@ module RouteTranslator
     end
 
     def self.translate_string(str, locale)
+      locale = "#{locale}".gsub('native_', '')
       res = I18n.translate(str, :scope => :routes, :locale => locale, :default => str)
       URI.escape(res)
     end

--- a/test/dummy/config/initializers/route_translator.rb
+++ b/test/dummy/config/initializers/route_translator.rb
@@ -1,0 +1,4 @@
+RouteTranslator.config do |config|
+  config.tld_locales[:es] = 'es'
+  config.tld_locales[:ru] = 'ru'
+end

--- a/test/dummy/config/locales/all.yml
+++ b/test/dummy/config/locales/all.yml
@@ -3,7 +3,10 @@
 
 en:
   routes:
-    dummy: 'dummy'
+    dummy: dummy
 es:
   routes:
-    dummy: 'dummy'
+    dummy: dummy
+ru:
+  routes:
+    dummy: манекен

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,3 +1,4 @@
+#encoding: utf-8
 require File.expand_path('../test_helper', __FILE__)
 require 'route_translator'
 require File.expand_path('../dummy/dummy_mounted_app', __FILE__)
@@ -20,13 +21,51 @@ class IntegrationTest < class_to_inherit
     assert_equal "Good", @response.body
     assert_response :success
   end
-  
+
   def test_i18n_locale_thread_safe
     config_default_locale_settings 'en'
-    
+
     get '/es/dummy'
     assert_equal 'es', @response.body
-    
+
     assert_equal :en, I18n.locale
+  end
+
+  def test_tld_locales
+    # root of es tld
+    host! 'testapp.es'
+    get '/'
+    assert_equal :es, I18n.locale
+    assert_equal :es, I18n.default_locale
+
+    # native es route on es tld
+    host! 'testapp.es'
+    get '/dummy'
+    assert_equal 'es', @response.body
+    assert_response :success
+
+    # ru route on es tld
+    host! 'testapp.es'
+    get URI.escape('/ru/манекен')
+    assert_equal 'ru', @response.body
+    assert_response :success
+
+    # root of ru tld
+    host! 'testapp.ru'
+    get '/'
+    assert_equal :ru, I18n.locale
+    assert_equal :ru, I18n.default_locale
+
+    # native ru route on ru tld
+    host! 'testapp.ru'
+    get URI.escape('/манекен')
+    assert_equal 'ru', @response.body
+    assert_response :success
+
+    # es route on ru tld
+    host! 'testapp.ru'
+    get '/es/dummy'
+    assert_equal 'es', @response.body
+    assert_response :success
   end
 end

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -22,6 +22,7 @@ class TranslateRoutesTest < ActionController::TestCase
     config_generate_unlocalized_routes false
     config_default_locale_settings("en")
     config_generate_unnamed_unlocalized_routes false
+    config_tld_locales({})
   end
 
   def test_unnamed_root_route
@@ -407,7 +408,7 @@ class TranslateRoutesTest < ActionController::TestCase
     # The dynamic route maps to the current locale
     assert_equal '/es/gente', @routes.url_helpers.people_path
   end
-  
+
   def test_blank_localized_routes
     I18n.locale = 'en'
     config_default_locale_settings 'en'
@@ -417,11 +418,11 @@ class TranslateRoutesTest < ActionController::TestCase
         get 'people/blank', :to => 'people#index', :as => 'people'
       end
     end
-    
+
     I18n.locale = 'en'
     assert_routing '/people/blank', :controller => 'people', :action => 'index', :locale => 'en'
     assert_equal '/people/blank', @routes.url_helpers.people_en_path
-    
+
     I18n.locale = 'es'
     assert_routing '/es/gente', :controller => 'people', :action => 'index', :locale => 'es'
     assert_equal '/es/gente', @routes.url_helpers.people_es_path
@@ -456,6 +457,22 @@ class TranslateRoutesTest < ActionController::TestCase
     assert_routing '/gente', :controller => 'people', :action => 'index', :locale => 'es'
     assert_routing '/people', :controller => 'people', :action => 'index', :locale => 'en'
   end
+
+  def test_tld_locales
+    config_tld_locales({ host: 'es', :'co.uk' => 'en' })
+
+    draw_routes do
+      localized do
+        resources :people
+      end
+      root :to => 'people#index'
+    end
+
+    assert_recognizes({controller: 'people', action: 'index', locale: 'es'}, {path: '/gente', method: :get})
+    assert_recognizes({controller: 'people', action: 'index', locale: 'es'}, {path: '/es/gente', method: :get})
+    assert_recognizes({controller: 'people', action: 'index', locale: 'en'}, {path: '/people', method: :get})
+  end
+
 
   def test_action_controller_gets_locale_setter
     ActionController::Base.instance_methods.include?('set_locale_from_url')
@@ -498,7 +515,6 @@ class ProductsControllerTest < ActionController::TestCase
   end
 
   def test_url_helpers_are_included
-
     #doing it this way because assert_nothing_raised doesn't work on all rails versions
     %w(product_path product_url product_es_path product_es_url).each do |method|
       begin

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,6 +57,10 @@ module RouteTranslator
       RouteTranslator.config.generate_unnamed_unlocalized_routes = boolean
     end
 
+    def config_tld_locales(hash)
+      RouteTranslator.config.tld_locales = hash.with_indifferent_access
+    end
+
     def path_string(route)
       path = route.respond_to?(:path) ? route.path : route.to_s.split(' ')[1]
       path.respond_to?(:spec) ? path.spec.to_s : path.to_s


### PR DESCRIPTION
close #59
This PR adds a configuration option `tld_locales` allowing the `default_locale` to be set dynamically based on the TLD of the host domain. This is useful for apps hosted on several different domains where the native locale may be different in each case.

When the option is blank, the gem behaves exactly as before, with the option enabled it does behave a little differently though so it's more like an alternative use-case than an additional option.
