### PR TITLE
Add dynamic native locales for apps with multiple hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,56 @@ end
   Defaults to `false`.
 * **locale_param_key** - The param key that will be used to set the
   locale to the newly generated routes. Defaults to :locale
+* **host_locales** - optional hash to set default_locale based on request.host,
+  useful for apps accepting requests from more than one domain. See below for
+  more details.
+
+### Host-based Locale
+If you have an application serving requests from more than one domain, you
+might want to set  default_locale dynamically based on which domain the request
+is coming from.  
+
+The `host_locales` option is a hash mapping hosts to locales, with full
+wildcard support to allow matching multiple domains/subdomains/tlds. Host
+matching is case insensitive. 
+
+When a request hits your app from a domain matching one of the wild-card
+matchers defined in `host_locales`, the default_locale will be set to the
+specified locale, and that locale will be hidden from routes (acting like a
+dynamic `hide_locale` option.
+
+Here are a few examples of possible mappings:
+
+```ruby
+RouteTranslator.config.host_locales = 
+{                                # Matches:
+  '*.es'                 => :es, # TLD:         ['domain.es', 'subdomain.domain.es', 'www.long.string.of.subdomains.es'] etc.
+  'ru.wikipedia.*'       => :ru, # Subdomain:   ['ru.wikipedia.org', 'ru.wikipedia.net', 'ru.wikipedia.com'] etc.
+  '*.subdomain.domain.*' => :ru, # Mixture:     ['subdomain.domain.org', 'www.subdomain.domain.net'] etc.
+  'news.bbc.co.uk'       => :en, # Exact match: ['news.bbc.co.uk'] only
+}
+```
+
+In the case of a host matching more than once, the order in which the matchers
+are defined will be taken into account, like so:
+
+```ruby
+RouteTranslator.config.host_locales = { 'russia.*' => :ru, '*.com'    => :en } # 'russia.com' will have locale :ru
+RouteTranslator.config.host_locales = { '*.com'    => :en, 'russia.*' => :ru } # 'russia.com' will have locale :en
+```
+
+If `host_locales` option is set, the following options will be forced (even if
+you set to true):
+
+```ruby
+@config.generate_unlocalized_routes         = false
+@config.generate_unnamed_unlocalized_routes = false
+@config.force_locale                        = false
+@config.hide_locale                         = false
+```
+
+This is to avoid odd behaviour brought about by route conflicts and because 
+`host_locales` forces and hides the host-locale dynamically.
 
 Contributing
 ------------

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -5,26 +5,38 @@ require 'action_dispatch'
 
 require File.expand_path('../route_translator/extensions', __FILE__)
 require File.expand_path('../route_translator/translator', __FILE__)
+require File.expand_path('../route_translator/host', __FILE__)
 
 module RouteTranslator
+  extend RouteTranslator::Host
 
   TRANSLATABLE_SEGMENT = /^([-_a-zA-Z0-9]+)(\()?/.freeze
 
-  Configuration = Struct.new(:force_locale, :hide_locale, :generate_unlocalized_routes, :locale_param_key, :generate_unnamed_unlocalized_routes)
+  Configuration = Struct.new(:force_locale, :hide_locale,
+                             :generate_unlocalized_routes, :locale_param_key,
+                             :generate_unnamed_unlocalized_routes,
+                             :host_locales)
 
   def self.config(&block)
-    @config ||= Configuration.new
-    @config.force_locale ||= false
-    @config.hide_locale ||= false
-    @config.generate_unlocalized_routes ||= false
-    @config.locale_param_key ||= :locale
+    @config                                     ||= Configuration.new
+    @config.force_locale                        ||= false
+    @config.hide_locale                         ||= false
+    @config.generate_unlocalized_routes         ||= false
+    @config.locale_param_key                    ||= :locale
     @config.generate_unnamed_unlocalized_routes ||= false
+    @config.host_locales                        ||= {}.with_indifferent_access
     yield @config if block
+    resolve_config_conflicts
     @config
   end
 
-  def self.locale_param_key
-    self.config.locale_param_key
+  def self.resolve_config_conflicts
+    if @config.host_locales.present?
+      @config.generate_unlocalized_routes         = false
+      @config.generate_unnamed_unlocalized_routes = false
+      @config.force_locale                        = false
+      @config.hide_locale                         = false
+      @config.host_locales                        = @config.host_locales.with_indifferent_access
+    end
   end
-
 end

--- a/lib/route_translator/extensions/action_controller.rb
+++ b/lib/route_translator/extensions/action_controller.rb
@@ -5,7 +5,23 @@ module ActionController
     around_filter :set_locale_from_url
 
     def set_locale_from_url(&block)
-      I18n.with_locale params[RouteTranslator.locale_param_key], &block
+      with_host_locale { I18n.with_locale(params[RouteTranslator.locale_param_key], &block) }
+    end
+
+    private
+    def with_host_locale(&block)
+      original_default         = I18n.default_locale
+      original_locale          = I18n.locale
+
+      if host_locale =  RouteTranslator::Host.locale_from_host(request.host)
+        I18n.default_locale = host_locale
+        I18n.locale         = host_locale
+      end
+
+      yield
+
+      I18n.default_locale = original_default
+      I18n.locale         = original_locale
     end
   end
 end

--- a/lib/route_translator/host.rb
+++ b/lib/route_translator/host.rb
@@ -1,0 +1,29 @@
+module RouteTranslator
+  module Host
+    def self.locale_from_host(host)
+      matches = RouteTranslator.config.host_locales.detect {|key, locale| host =~ regex_for(key) }
+      matched_locale = if matches && host_match = matches.first
+                         locale   = RouteTranslator.config.host_locales[host_match].to_sym
+                         locale if I18n.available_locales.include?(locale)
+                       end
+      matched_locale || I18n.default_locale
+    end
+
+    def self.regex_for(host_string)
+      escaped = Regexp.escape(host_string).gsub('\*', '.*?').gsub('\.', '\.?')
+      Regexp.new("^#{escaped}$", Regexp::IGNORECASE)
+    end
+
+    def native_locale?(locale)
+      !!locale.to_s.match(/native_/)
+    end
+
+    def native_locales
+      config.host_locales.values.map {|locale| :"native_#{locale}" }
+    end
+
+    def locale_param_key
+      self.config.locale_param_key
+    end
+  end
+end

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -12,32 +12,35 @@ module RouteTranslator
         helper_list.push(new_helper_name.to_sym) unless helper_list.include?(new_helper_name.to_sym)
 
         helper_container.__send__(:define_method, new_helper_name) do |*args|
-          locale_suffix = I18n.locale.to_s.underscore
-          if respond_to?("#{old_name}_#{locale_suffix}_#{suffix}")
+          locale_suffix         = I18n.locale.to_s.underscore
+          default_locale_suffix = I18n.default_locale.to_s.underscore
+          args_hash             = args.select {|arg| arg.is_a?(Hash) }.first
+          args_locale_suffix    = args_hash[:locale].to_s.underscore if args_hash.present?
+          if RouteTranslator.config.host_locales.present?
+            if args.blank? || args_locale_suffix == default_locale_suffix
+            __send__("#{old_name}_native_#{default_locale_suffix}_#{suffix}", *args)
+            elsif args_locale_suffix
+            __send__("#{old_name}_#{args_locale_suffix}_#{suffix}", *args)
+            end
+          elsif respond_to?("#{old_name}_#{locale_suffix}_#{suffix}")
             __send__("#{old_name}_#{locale_suffix}_#{suffix}", *args)
           else
             __send__("#{old_name}_#{I18n.default_locale.to_s.underscore}_#{suffix}", *args)
           end
         end
-
       end
     end
 
     def self.translations_for(app, conditions, requirements, defaults, route_name, anchor, route_set, &block)
       add_untranslated_helpers_to_controllers_and_views(route_name, route_set.named_routes.module, route_set.named_routes.helpers)
-      # Make sure the default locale is translated in last place to avoid
-      # problems with wildcards when default locale is omitted in paths. The
-      # default routes will catch all paths like wildcard if it is translated first
-      available_locales = I18n.available_locales.dup
-      available_locales.delete I18n.default_locale
-      available_locales.push I18n.default_locale
+
       available_locales.each do |locale|
         new_conditions = conditions.dup
         new_conditions[:path_info] = translate_path(conditions[:path_info], locale)
         if new_conditions[:required_defaults] && !new_conditions[:required_defaults].include?(RouteTranslator.locale_param_key)
           new_conditions[:required_defaults] << RouteTranslator.locale_param_key if new_conditions[:required_defaults]
         end
-        new_defaults = defaults.merge(RouteTranslator.locale_param_key => locale.to_s)
+        new_defaults = defaults.merge(RouteTranslator.locale_param_key => locale.to_s.gsub('native_', ''))
         new_requirements = requirements.merge(RouteTranslator.locale_param_key => locale.to_s)
         new_route_name = translate_name(route_name, locale)
         new_route_name = nil if new_route_name && route_set.named_routes.routes[new_route_name.to_sym] #TODO: Investigate this :(
@@ -50,20 +53,24 @@ module RouteTranslator
       end
     end
 
+    private
+    def self.available_locales
+      available_locales = I18n.available_locales.dup
+      available_locales.push *RouteTranslator.native_locales if RouteTranslator.native_locales.present?
+      # Make sure the default locale is translated in last place to avoid
+      # problems with wildcards when default locale is omitted in paths. The
+      # default routes will catch all paths like wildcard if it is translated first.
+      available_locales.push(available_locales.delete(I18n.default_locale))
+    end
+
     # Translates a path and adds the locale prefix.
     def self.translate_path(path, locale)
       new_path = path.dup
       final_optional_segments = new_path.slice!(/(\([^\/]+\))$/)
       translated_segments = new_path.split(/\/|\./).map{ |seg| translate_path_segment(seg, locale) }.select{ |seg| !seg.blank? }
 
-      # if not hiding locale then
-      # add locale prefix if it's not the default locale,
-      # or forcing locale to all routes,
-      # or already generating actual unlocalized routes
-      if !RouteTranslator.config.hide_locale && (!default_locale?(locale) || RouteTranslator.config.force_locale || RouteTranslator.config.generate_unlocalized_routes || RouteTranslator.config.generate_unnamed_unlocalized_routes)
-        if !locale_param_present?(new_path)
-          translated_segments.unshift locale.to_s.downcase
-        end
+      if display_locale?(locale) && !locale_param_present?(new_path)
+        translated_segments.unshift(locale.to_s.downcase)
       end
 
       joined_segments = translated_segments.inject do |memo, segment|
@@ -72,6 +79,14 @@ module RouteTranslator
       end
 
       "/#{joined_segments}#{final_optional_segments}".gsub(/\/\(\//, '(/')
+    end
+
+    def self.display_locale?(locale)
+      !RouteTranslator.config.hide_locale && !RouteTranslator.native_locale?(locale) &&
+        (!default_locale?(locale) ||
+         RouteTranslator.config.force_locale ||
+         RouteTranslator.config.generate_unlocalized_routes ||
+         RouteTranslator.config.generate_unnamed_unlocalized_routes)
     end
 
     def self.translate_name(n, locale)
@@ -87,7 +102,7 @@ module RouteTranslator
     # "people" will be translated, if there is no translation, the path
     # segment is blank, begins with a ":" (param key) or "*" (wildcard),
     # the segment is returned untouched
-    def self.translate_path_segment segment, locale
+    def self.translate_path_segment(segment, locale)
       return segment if segment.blank? or segment.starts_with?(":") or segment.starts_with?("(") or segment.starts_with?("*")
 
       appended_part = segment.slice!(/(\()$/)
@@ -97,7 +112,8 @@ module RouteTranslator
     end
 
     def self.translate_string(str, locale)
-      res = I18n.translate(str, :scope => :routes, :locale => locale, :default => str)
+      locale = "#{locale}".gsub('native_', '')
+      res    = I18n.translate(str, :scope => :routes, :locale => locale, :default => str)
       URI.escape(res)
     end
 

--- a/test/dummy/config/initializers/route_translator.rb
+++ b/test/dummy/config/initializers/route_translator.rb
@@ -1,0 +1,4 @@
+RouteTranslator.config do |config|
+  config.host_locales['*.es'] = 'es'
+  config.host_locales['ru.*.com'] = 'ru'
+end

--- a/test/dummy/config/locales/all.yml
+++ b/test/dummy/config/locales/all.yml
@@ -3,7 +3,10 @@
 
 en:
   routes:
-    dummy: 'dummy'
+    dummy: dummy
 es:
   routes:
-    dummy: 'dummy'
+    dummy: dummy
+ru:
+  routes:
+    dummy: манекен

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -2,5 +2,8 @@ Dummy::Application.routes.draw do
   localized do
     get 'dummy', :to => 'dummy#dummy'
   end
+
+  root :to => 'dummy#dummy'
+
   mount DummyMountedApp.new => '/dummy_mounted_app'
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,3 +1,4 @@
+#encoding: utf-8
 require File.expand_path('../test_helper', __FILE__)
 require 'route_translator'
 require File.expand_path('../dummy/dummy_mounted_app', __FILE__)
@@ -20,13 +21,50 @@ class IntegrationTest < class_to_inherit
     assert_equal "Good", @response.body
     assert_response :success
   end
-  
+
   def test_i18n_locale_thread_safe
     config_default_locale_settings 'en'
-    
     get '/es/dummy'
     assert_equal 'es', @response.body
-    
+
     assert_equal :en, I18n.locale
+  end
+
+  def test_host_locales
+    ## root of es com
+    #host! 'www.testapp.es'
+    #get '/'
+    #assert_equal 'es', @response.body
+    #assert_response :success
+
+    ## native es route on es com
+    #host! 'www.testapp.es'
+    #get '/dummy'
+    #assert_equal 'es', @response.body
+    #assert_response :success
+
+    ## ru route on es com
+    #host! 'www.testapp.es'
+    #get URI.escape('/ru/манекен')
+    #assert_equal 'ru', @response.body
+    #assert_response :success
+
+    ## root of ru com
+    host! 'ru.testapp.com'
+    get '/'
+    assert_equal 'ru', @response.body
+    assert_response :success
+
+    ## native ru route on ru com
+    #host! 'ru.testapp.com'
+    #get URI.escape('/манекен')
+    #assert_equal 'ru', @response.body
+    #assert_response :success
+
+    ## es route on ru com
+    #host! 'ru.testapp.com'
+    #get '/es/dummy'
+    #assert_equal 'es', @response.body
+    #assert_response :success
   end
 end

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -22,6 +22,7 @@ class TranslateRoutesTest < ActionController::TestCase
     config_generate_unlocalized_routes false
     config_default_locale_settings("en")
     config_generate_unnamed_unlocalized_routes false
+    config_host_locales({})
   end
 
   def test_unnamed_root_route
@@ -94,7 +95,6 @@ class TranslateRoutesTest < ActionController::TestCase
         resources :products
       end
     end
-
 
     assert_routing '/en/products', :controller => 'products', :action => 'index', :locale => 'en'
     assert_routing '/productos', :controller => 'products', :action => 'index', :locale => 'es'
@@ -431,7 +431,7 @@ class TranslateRoutesTest < ActionController::TestCase
     # The dynamic route maps to the current locale
     assert_equal '/es/gente', @routes.url_helpers.people_path
   end
-  
+
   def test_blank_localized_routes
     I18n.locale = 'en'
     config_default_locale_settings 'en'
@@ -441,11 +441,11 @@ class TranslateRoutesTest < ActionController::TestCase
         get 'people/blank', :to => 'people#index', :as => 'people'
       end
     end
-    
+
     I18n.locale = 'en'
     assert_routing '/people/blank', :controller => 'people', :action => 'index', :locale => 'en'
     assert_equal '/people/blank', @routes.url_helpers.people_en_path
-    
+
     I18n.locale = 'es'
     assert_routing '/es/gente', :controller => 'people', :action => 'index', :locale => 'es'
     assert_equal '/es/gente', @routes.url_helpers.people_es_path
@@ -481,6 +481,22 @@ class TranslateRoutesTest < ActionController::TestCase
     assert_routing '/people', :controller => 'people', :action => 'index', :locale => 'en'
   end
 
+  def test_host_locales
+    config_host_locales({ :host => 'es', :'co.uk' => 'en' })
+
+    draw_routes do
+      localized do
+        resources :people
+      end
+      root :to => 'people#index'
+    end
+
+    assert_recognizes({:controller => 'people', :action => 'index', :locale => 'es'}, {:path => '/gente',   :method => :get})
+    assert_recognizes({:controller => 'people', :action => 'index', :locale => 'es'}, {:path => '/es/gente',:method => :get})
+    assert_recognizes({:controller => 'people', :action => 'index', :locale => 'en'}, {:path => '/people',  :method => :get})
+  end
+
+
   def test_action_controller_gets_locale_setter
     ActionController::Base.instance_methods.include?('set_locale_from_url')
   end
@@ -504,7 +520,8 @@ class ProductsControllerTest < ActionController::TestCase
     I18n.load_path = [ File.expand_path('../locales/routes.yml', __FILE__) ]
     I18n.reload!
 
-    config_default_locale_settings 'en'
+    config_default_locale_settings 'es'
+    config_host_locales({:es => 'es'})
 
     draw_routes do
       localized do
@@ -519,12 +536,12 @@ class ProductsControllerTest < ActionController::TestCase
     config_generate_unlocalized_routes false
     config_default_locale_settings("en")
     config_generate_unnamed_unlocalized_routes false
+    config_host_locales({})
   end
 
   def test_url_helpers_are_included
-
     #doing it this way because assert_nothing_raised doesn't work on all rails versions
-    %w(product_path product_url product_es_path product_es_url).each do |method|
+    %w(product_path product_url product_es_path product_es_url product_native_es_path product_native_es_url).each do |method|
       begin
         send(method)
       rescue Exception => e
@@ -533,4 +550,3 @@ class ProductsControllerTest < ActionController::TestCase
     end
   end
 end
-

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,6 +57,10 @@ module RouteTranslator
       RouteTranslator.config.generate_unnamed_unlocalized_routes = boolean
     end
 
+    def config_host_locales(hash)
+      RouteTranslator.config.host_locales = hash.with_indifferent_access
+    end
+
     def path_string(route)
       path = route.respond_to?(:path) ? route.path : route.to_s.split(' ')[1]
       path.respond_to?(:spec) ? path.spec.to_s : path.to_s

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -1,0 +1,99 @@
+require File.expand_path(File.join(File.dirname(__FILE__), 'test_helper'))
+require 'route_translator'
+
+class TestHostsFromLocale < MiniTest::Unit::TestCase
+  include RouteTranslator::TestHelper
+  def setup
+    I18n.backend        = I18n::Backend::Simple.new
+    I18n.load_path      = [ File.expand_path('../locales/routes.yml', __FILE__) ]
+    I18n.reload!
+
+    config_host_locales({
+      '*.something.es'           => :es,
+      '*.ru.subdomain.domain.*'  => :ru,
+      'russia.something.net'     => :ru,
+      '*.com'                    => :en
+    })
+  end
+
+  def teardown
+    config_host_locales({})
+    I18n.default_locale = :en
+  end
+
+  def test_wildcard_at_beginning_matches
+    assert_equal :en, RouteTranslator::Host.locale_from_host('something.com')
+  end
+
+  def test_wildcard_at_beginning_with_subdomain_matches
+    assert_equal :en, RouteTranslator::Host.locale_from_host('www.domain.com')
+  end
+
+  def test_wildcard_at_beginning_without_subdomain_matches
+    assert_equal :en, RouteTranslator::Host.locale_from_host('domain.com')
+  end
+
+  def test_wildcard_at_end_with_subdomain_matches
+    assert_equal :es, RouteTranslator::Host.locale_from_host('www.something.es')
+  end
+
+  def test_wildcard_at_end_without_subdomain_matches
+    assert_equal :es, RouteTranslator::Host.locale_from_host('something.es')
+  end
+
+  def test_no_wildcard_matches
+    assert_equal :ru, RouteTranslator::Host.locale_from_host('russia.something.net')
+  end
+
+  def test_multiple_wildcard_matches
+    assert_equal :ru, RouteTranslator::Host.locale_from_host('www.ru.subdomain.domain.biz')
+  end
+
+  def test_case_is_ignored
+    assert_equal :es, RouteTranslator::Host.locale_from_host('www.SoMeThInG.ES')
+  end
+
+  def test_precedence_if_more_than_one_match
+    config_host_locales({ 'russia.*'  => :ru, '*.com' => :en })
+    assert_equal :ru, RouteTranslator::Host.locale_from_host('russia.com')
+
+    config_host_locales({ '*.com' => :en, 'russia.*'  => :ru })
+    assert_equal :en, RouteTranslator::Host.locale_from_host('russia.com')
+  end
+
+  def test_default_locale_if_no_matches
+    assert_equal I18n.default_locale, RouteTranslator::Host.locale_from_host('nomatches.co.uk')
+  end
+
+  def test_readme_examples_work
+    config_host_locales(
+      {
+        '*.es'                  => :es, # matches ['domain.es', 'subdomain.domain.es', 'www.long.string.of.subdomains.es'] etc.
+        'ru.wikipedia.*'        => :ru, # matches ['ru.wikipedia.org', 'ru.wikipedia.net', 'ru.wikipedia.com'] etc.
+        '*.subdomain.domain.*'  => :ru, # matches ['subdomain.domain.org', 'www.subdomain.domain.net'] etc.
+        'news.bbc.co.uk'        => :en, # matches ['news.bbc.co.uk'] only
+      }
+    )
+
+    examples_1 = ['domain.es', 'subdomain.domain.es', 'www.long.string.of.subdomains.es']
+    examples_2 = ['ru.wikipedia.org', 'ru.wikipedia.net', 'ru.wikipedia.com']
+    examples_3 = ['subdomain.domain.org', 'www.subdomain.domain.net']
+    examples_4 = ['news.bbc.co.uk']
+
+    examples_1.each do |domain|
+      assert_equal :es, RouteTranslator::Host.locale_from_host(domain)
+    end
+
+    examples_2.each do |domain|
+      assert_equal :ru, RouteTranslator::Host.locale_from_host(domain)
+    end
+
+    examples_3.each do |domain|
+      assert_equal :ru, RouteTranslator::Host.locale_from_host(domain)
+    end
+
+    examples_4.each do |domain|
+      assert_equal :en, RouteTranslator::Host.locale_from_host(domain)
+    end
+  end
+end


### PR DESCRIPTION
close #59
This PR adds a configuration option tld_locales allowing the default_locale to be set dynamically based on the TLD of the host domain. This is useful for apps hosted on several different domains where the native locale may be different in each case.

When the option is blank, the gem behaves exactly as before, with the option enabled it does behave a little differently though so it's more like an alternative use-case than an additional option.
