### PR TITLE
fix path helpers returning nil with certain arguments

### DIFF
--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -39,4 +39,8 @@ module RouteTranslator
       @config.host_locales                        = @config.host_locales.with_indifferent_access
     end
   end
+
+  def self.locale_param_key
+    self.config.locale_param_key
+  end
 end

--- a/lib/route_translator/host.rb
+++ b/lib/route_translator/host.rb
@@ -21,9 +21,5 @@ module RouteTranslator
     def native_locales
       config.host_locales.values.map {|locale| :"native_#{locale}" }
     end
-
-    def locale_param_key
-      self.config.locale_param_key
-    end
   end
 end

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -16,12 +16,11 @@ module RouteTranslator
           default_locale_suffix = I18n.default_locale.to_s.underscore
           args_hash             = args.select {|arg| arg.is_a?(Hash) }.first
           args_locale_suffix    = args_hash[:locale].to_s.underscore if args_hash.present?
-          if RouteTranslator.config.host_locales.present?
-            if args.blank? || args_locale_suffix == default_locale_suffix
+
+          if RouteTranslator.config.host_locales.present? && (args_hash.blank? || args_locale_suffix == default_locale_suffix)
             __send__("#{old_name}_native_#{default_locale_suffix}_#{suffix}", *args)
-            elsif args_locale_suffix
+          elsif RouteTranslator.config.host_locales.present? && args_locale_suffix.present?
             __send__("#{old_name}_#{args_locale_suffix}_#{suffix}", *args)
-            end
           elsif respond_to?("#{old_name}_#{locale_suffix}_#{suffix}")
             __send__("#{old_name}_#{locale_suffix}_#{suffix}", *args)
           else

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -450,6 +450,25 @@ class TranslateRoutesTest < ActionController::TestCase
     assert_equal '/es/gente', @routes.url_helpers.people_es_path
   end
 
+  def test_path_helper_arguments
+    config_default_locale_settings 'es'
+    config_host_locales({ '*.es' => 'es', '*.com' => 'en' })
+
+    draw_routes do
+      localized do
+        resources :products
+      end
+    end
+
+    assert_equal '/productos',                           @routes.url_helpers.products_path
+    assert_equal '/productos/some_product',              @routes.url_helpers.product_path('some_product')
+    assert_equal '/productos/some_product?some=param',   @routes.url_helpers.product_path('some_product', :some => 'param')
+    assert_equal '/en/products',                         @routes.url_helpers.products_path(:locale => 'en')
+    assert_equal '/en/products/some_product',            @routes.url_helpers.product_path('some_product', :locale => 'en')
+    assert_equal '/en/products/some_product?some=param', @routes.url_helpers.product_path('some_product', :locale => 'en', :some => 'param')
+  end
+
+
   def test_dont_add_locale_to_routes_if_local_param_present
     config_default_locale_settings 'es'
     config_force_locale true


### PR DESCRIPTION
@gi-lunaweb unfortunately I introduced a bug in my last PR (the bug only occurs when using the host_locales option). The path helpers were incorrectly returning nil when given anything other than a hash as an argument. This PR fixes the bug and adds a test for it.

I also moved locale_param_key back to lib/route_translator.rb, I had moved this to lib/route_translator/host.rb but I think it makes more sense in its original position.
