### PR TITLE
Improved action controller

### DIFF
--- a/lib/route_translator/extensions/action_controller.rb
+++ b/lib/route_translator/extensions/action_controller.rb
@@ -4,30 +4,24 @@ module ActionController
   class Base
     around_filter :set_locale_from_url
 
-    def set_locale_from_url(&block)
-      with_host_locale { I18n.with_locale(params[RouteTranslator.locale_param_key], &block) }
-    end
-
-    private
-
-    def with_host_locale(&block)
-      host_locale = RouteTranslator::Host.locale_from_host(request.host)
-      begin
-        if host_locale
-          original_default         = I18n.default_locale
-          original_locale          = I18n.locale
-
-          I18n.default_locale = host_locale
-          I18n.locale         = host_locale
-        end
-
-        yield
-
-      ensure
-        I18n.default_locale = original_default if host_locale
-        I18n.locale         = original_locale  if host_locale
+    def set_locale_from_url
+      tmp_default_locale = RouteTranslator::Host.locale_from_host(request.host)
+      if tmp_default_locale
+        current_default_locale = I18n.default_locale
+        I18n.default_locale    = tmp_default_locale
       end
-    end
 
+      tmp_locale = params[RouteTranslator.locale_param_key] || tmp_default_locale
+      if tmp_locale
+        current_locale = I18n.locale
+        I18n.locale    = tmp_locale
+      end
+
+      yield
+
+    ensure
+      I18n.default_locale = current_default_locale if tmp_default_locale
+      I18n.locale = current_locale if tmp_locale
+    end
   end
 end


### PR DESCRIPTION
Based on how `I18n.with_locale` is implemented (https://github.com/svenfuchs/i18n/blob/master/lib/i18n.rb#L252) I tried to improve the action controller.

I aimed to avoid unnecessary function calls to `I18n.with_locale` and `self.with_host_locale`, assignments and nested block call. Moreover, the new approach [should be faster](https://speakerdeck.com/sferik/writing-fast-ruby?slide=12) but I'm very new to profiling so maybe you are interested in writing proper performance tests 

Beside gem's own tests, I launched some of my applications specs:

```
Using route_translator 3.2.4 from source at ~/dev/route_translator

Finished in 2 minutes 36.1 seconds (files took 11.93 seconds to load)
317 examples, 0 failures
```

```
Using route_translator 3.2.4 from source at ~/dev/route_translator

Finished in 4 minutes 10.2 seconds (files took 11.38 seconds to load)
409 examples, 0 failures
```

```
Using route_translator 3.2.4 from source at ~/dev/route_translator

Finished in 1 minute 11.67 seconds (files took 11.85 seconds to load)
188 examples, 0 failures, 1 pending
```
