### PR TITLE
Specify locales in config options.

### DIFF
--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -11,7 +11,7 @@ module RouteTranslator
 
   Configuration = Struct.new(:force_locale, :hide_locale,
                              :generate_unlocalized_routes, :locale_param_key,
-                             :generate_unnamed_unlocalized_routes,
+                             :generate_unnamed_unlocalized_routes, :available_locales,
                              :host_locales)
 
   def self.config(&block)
@@ -22,6 +22,7 @@ module RouteTranslator
     @config.locale_param_key                    ||= :locale
     @config.generate_unnamed_unlocalized_routes ||= false
     @config.host_locales                        ||= ActiveSupport::OrderedHash.new
+    @config.available_locales                   ||= nil
     yield @config if block
     resolve_config_conflicts
     @config

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -57,12 +57,18 @@ module RouteTranslator
 
     private
     def self.available_locales
-      available_locales = I18n.available_locales.dup
+      available_locales = config_locales || I18n.available_locales.dup
       available_locales.push(*RouteTranslator.native_locales) if RouteTranslator.native_locales.present?
       # Make sure the default locale is translated in last place to avoid
       # problems with wildcards when default locale is omitted in paths. The
       # default routes will catch all paths like wildcard if it is translated first.
       available_locales.push(available_locales.delete(I18n.default_locale))
+    end
+
+    def self.config_locales
+      if RouteTranslator.config.available_locales
+        RouteTranslator.config.available_locales.map{|l| l.to_sym}
+      end
     end
 
     # Translates a path and adds the locale prefix.

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -537,6 +537,39 @@ class TranslateRoutesTest < ActionController::TestCase
     assert_routing '/path/to/another/product', :controller => 'products', :action => 'show', :id => 'path/to/another/product'
   end
 
+
+  def test_config_available_locales
+    config_available_locales [:en, :ru]
+
+    draw_routes do
+      localized do
+        resources :people
+      end
+    end
+
+    assert_routing URI.escape('/ru/люди'), :controller => 'people', :action => 'index', :locale => 'ru'
+    assert_routing '/people', :controller => 'people', :action => 'index', :locale => 'en'
+    assert_unrecognized_route '/es/gente', :controller => 'people', :action => 'index', :locale => 'es'
+
+    config_available_locales nil
+  end
+
+  def test_config_available_locales_handles_strings
+    config_available_locales %w( en ru )
+
+    draw_routes do
+      localized do
+        resources :people
+      end
+    end
+
+    assert_routing URI.escape('/ru/люди'), :controller => 'people', :action => 'index', :locale => 'ru'
+    assert_routing '/people', :controller => 'people', :action => 'index', :locale => 'en'
+    assert_unrecognized_route '/es/gente', :controller => 'people', :action => 'index', :locale => 'es'
+
+    config_available_locales nil
+  end
+
 end
 
 class ProductsControllerTest < ActionController::TestCase

--- a/test/support/configuration_helper.rb
+++ b/test/support/configuration_helper.rb
@@ -39,6 +39,10 @@ module RouteTranslator
       RouteTranslator.config.host_locales = hash
     end
 
+    def config_available_locales(arr)
+      RouteTranslator.config.available_locales = arr
+    end
+
     def host_locales_config_hash
       if RUBY_VERSION < '1.9'
         ::ActiveSupport::OrderedHash.new


### PR DESCRIPTION
Our app does not specify available_locales because we allow users to post in any locale they wish and then we do some translation magic later on. However, that doesn't necessarily mean we want all our routes translated for all locales in the Rails stack. In our case, we only want to provide translated routes for two languages.

This configuration setting will allow the gem to accept which locales the end-user would like to translate in the event that they haven't specified `available_locales` in their Rails stack.