### PR TITLE
Allow disabling i18n fallback to not have unecessary routes

### DIFF
--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -12,7 +12,7 @@ module RouteTranslator
   Configuration = Struct.new(:force_locale, :hide_locale,
                              :generate_unlocalized_routes, :locale_param_key,
                              :generate_unnamed_unlocalized_routes, :available_locales,
-                             :host_locales)
+                             :host_locales, :disable_fallback)
 
   def self.config(&block)
     @config                                     ||= Configuration.new
@@ -23,6 +23,7 @@ module RouteTranslator
     @config.generate_unnamed_unlocalized_routes ||= false
     @config.host_locales                        ||= ActiveSupport::OrderedHash.new
     @config.available_locales                   ||= nil
+    @config.disable_fallback                    ||= false
     yield @config if block
     resolve_config_conflicts
     @config

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -570,6 +570,22 @@ class TranslateRoutesTest < ActionController::TestCase
     config_available_locales nil
   end
 
+  def test_disable_fallback_does_not_draw_non_default_routes
+    config_disable_fallback(true)
+
+    draw_routes do
+      localized do
+        get 'tr_param', :to => 'people#index', :as => 'people'
+      end
+    end
+
+    config_disable_fallback(false)
+
+    assert_routing '/tr_param', :controller => 'people', :action => 'index', :locale => 'en'
+    assert_routing '/es/tr_parametro', :controller => 'people', :action => 'index', :locale => 'es'
+    assert_unrecognized_route '/ru/tr_param', :controller => 'people', :action => 'index', :locale => 'ru'
+  end
+
 end
 
 class ProductsControllerTest < ActionController::TestCase

--- a/test/support/configuration_helper.rb
+++ b/test/support/configuration_helper.rb
@@ -43,6 +43,10 @@ module RouteTranslator
       RouteTranslator.config.available_locales = arr
     end
 
+    def config_disable_fallback(boolean)
+      RouteTranslator.config.disable_fallback = boolean
+    end
+
     def host_locales_config_hash
       if RUBY_VERSION < '1.9'
         ::ActiveSupport::OrderedHash.new


### PR DESCRIPTION
Currently all routes fallback to english version if the translation is missing. This leads to the routes that look something like:
```
online_examples_es GET  /ejemplos(.:format)    online#examples {:_locale=>"es"}
online_examples_fr GET  /examples(.:format)    online#examples {:_locale=>"fr"}
online_examples_en GET  /examples(.:format)    online#examples {:_locale=>"en"}
```

If you notice that for fr we have english route which is undesirable.
To solve this issue, we have added support for disabling fallback so that routes which don't have translation don't show up in routes.

```
online_examples_es GET  /ejemplos(.:format)    online#examples {:_locale=>"es"}
online_examples_en GET  /examples(.:format)    online#examples {:_locale=>"en"}
```

@mattvleming @enriclluelles @tagliala 