### PR TITLE
force locale for / even hide_locale is set to true

### DIFF
--- a/lib/route_translator/extensions/action_controller.rb
+++ b/lib/route_translator/extensions/action_controller.rb
@@ -10,6 +10,12 @@ module ActionController
         current_default_locale = I18n.default_locale
         I18n.default_locale    = tmp_default_locale
       end
+      
+      if !session[:redirected_to_accept_language]
+        tmp_locale = http_accept_language.compatible_language_from(I18n.available_locales) || tmp_default_locale
+        session[:redirected_to_accept_language] = true
+        return redirect_to url_for(locale: tmp_locale.to_s)
+      end
 
       tmp_locale = params[RouteTranslator.locale_param_key] || tmp_default_locale
       if tmp_locale

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -82,7 +82,7 @@ module RouteTranslator
       final_optional_segments = new_path.slice!(/(\([^\/]+\))$/)
       translated_segments = new_path.split(/\/|\./).map{ |seg| translate_path_segment(seg, locale) }.select{ |seg| !seg.blank? }
 
-      if display_locale?(locale) && !locale_param_present?(new_path)
+      if (path == '/' && !default_locale?(locale)) || (display_locale?(locale) && !locale_param_present?(new_path))
         translated_segments.unshift(locale.to_s.downcase)
       end
 


### PR DESCRIPTION
I found an issue when I use **hide_locale** and I try to localize my **root_path**. 

    root_fr GET        /                home#index {:locale=>"fr"}
    root_en GET        /                home#index {:locale=>"en"}

The problem is that I have the same route with different locale.

So to solve this problem I forced the locale only when the path is '/' and the current locale is not the default one.

So if en is the default locale when I call **root_fr_path** with **hide_locale** to true I will have '/fr' but if I call whatever_fr_path I will have '/whatever'.

    root_fr GET        /fr              home#index {:locale=>"fr"}
    root_en GET        /                home#index {:locale=>"en"}


