### PR TITLE
Add custom path separator characters ('-' as example) and params in the middle

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ end
   For example if we have `/examples` and a translation is not provided for ES, a route helper of `examples_es` will not be created.
   Defaults to `false`.
   Useful when one uses this with a locale route constraint, so non-ES routes can 404 on a Spanish website.
+* **path_separator**
+  Set this option to force a different path separator (like `-` instead of `/`).
+  Useful if you have edited `ActionDispatch::Routing::SEPARATORS`.
+  This must be a single character which is not used (without escaping) in parameters.
 
 ### Host-based Locale
 

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -12,7 +12,7 @@ module RouteTranslator
   Configuration = Struct.new(:force_locale, :hide_locale,
                              :generate_unlocalized_routes, :locale_param_key,
                              :generate_unnamed_unlocalized_routes, :available_locales,
-                             :host_locales, :disable_fallback)
+                             :host_locales, :disable_fallback, :path_separator)
 
   def self.config(&block)
     @config                                     ||= Configuration.new
@@ -24,6 +24,7 @@ module RouteTranslator
     @config.host_locales                        ||= ActiveSupport::OrderedHash.new
     @config.available_locales                   ||= nil
     @config.disable_fallback                    ||= false
+    @config.path_separator                      ||= '/'
     yield @config if block
     resolve_config_conflicts
     @config

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -78,20 +78,22 @@ module RouteTranslator
 
     # Translates a path and adds the locale prefix.
     def self.translate_path(path, locale)
+      sep = RouteTranslator.config.path_separator
       new_path = path.dup
-      final_optional_segments = new_path.slice!(/(\([^\/]+\))$/)
-      translated_segments = new_path.split(/\/|\./).map{ |seg| translate_path_segment(seg, locale) }.select{ |seg| !seg.blank? }
+      final_optional_segments = new_path.slice!(/(\([^#{sep}]+\))$/)
+      segments = new_path.split(/\/|\.|#{sep}/)
+      translated_segments = segments.map{ |seg| translate_path_segment(seg, locale) }.select{ |seg| !seg.blank? }
 
       if display_locale?(locale) && !locale_param_present?(new_path)
         translated_segments.unshift(locale.to_s.downcase)
       end
 
       joined_segments = translated_segments.inject do |memo, segment|
-        separator = segment == ':format' ? '.' : '/'
+        separator = segment == ':format' ? '.' : sep
         memo << separator << segment
       end
 
-      "/#{joined_segments}#{final_optional_segments}".gsub(/\/\(\//, '(/')
+      "/#{joined_segments}#{final_optional_segments}".gsub(/#{sep}\(#{sep}/, "(#{sep}")
     end
 
     def self.display_locale?(locale)

--- a/test/locales/routes.yml
+++ b/test/locales/routes.yml
@@ -1,6 +1,7 @@
 es:
   routes:
     people: gente
+    units: unidades
     products: productos
     tr_param: tr_parametro
     blank: ""

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -75,6 +75,38 @@ class TranslateRoutesTest < ActionController::TestCase
     assert_routing '/es/productos/a', :controller => 'products', :action => 'index', :locale => 'es', :tr_param => 'a'
   end
 
+  def test_dynamic_segments_dont_get_translated_dash_separator
+    ActionDispatch::Routing::SEPARATORS << "-" unless ActionDispatch::Routing::SEPARATORS.include?("-")
+    config_path_separator '-'
+    draw_routes do
+      localized do
+        get 'products-:tr_param', :to => 'products#index', :constraints => { :tr_param => /\w/ }
+      end
+    end
+    assert_routing '/es-productos-a', :controller => 'products', :action => 'index', :locale => 'es', :tr_param => 'a'
+  end
+
+  def test_dynamic_segments_in_the_middle
+    draw_routes do
+      localized do
+        get 'products/:tr_param/units', :to => 'products#units', :constraints => { :tr_param => /\w+/ }
+      end
+    end
+    assert_routing '/es/productos/a/unidades', :controller => 'products', :action => 'units', :locale => 'es', :tr_param => 'a'
+  end
+
+  def test_dynamic_segments_with_dash_separator_and_hide_locale
+    ActionDispatch::Routing::SEPARATORS << "-" unless ActionDispatch::Routing::SEPARATORS.include?("-")
+    config_hide_locale true
+    config_path_separator '-'
+    draw_routes do
+      localized do
+        get 'products-:tr_param-units', :to => 'products#units', :constraints => { :tr_param => /\w+/ }
+      end
+    end
+    assert_routing '/productos-a-unidades', :controller => 'products', :action => 'units', :locale => 'es', :tr_param => 'a'
+  end
+
   def test_wildcards_dont_get_translated
     draw_routes do
       localized do

--- a/test/support/configuration_helper.rb
+++ b/test/support/configuration_helper.rb
@@ -8,6 +8,7 @@ module RouteTranslator
       config_generate_unlocalized_routes false
       config_generate_unnamed_unlocalized_routes false
       config_host_locales(host_locales_config_hash)
+      config_path_separator '/'
 
       config_default_locale_settings(:en)
     end
@@ -45,6 +46,10 @@ module RouteTranslator
 
     def config_disable_fallback(boolean)
       RouteTranslator.config.disable_fallback = boolean
+    end
+
+    def config_path_separator(char)
+      RouteTranslator.config.path_separator = char
     end
 
     def host_locales_config_hash


### PR DESCRIPTION
See issue #105. The issue here seems (maybe among others) that `translator.rb::translate_path` assumes "/", "." and "?" as path separators and ignores `ActionDispatch::Routing::SEPARATORS`. 