### PR TITLE
Fixing native path generation issue

### DIFF
--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -156,6 +156,8 @@ module RouteTranslator
 
       locale = if args_locale
                  args_locale.to_s.underscore
+               elsif kaller.respond_to?("#{old_name}_native_#{current_locale_name}_#{suffix}")
+                "native_#{current_locale_name}"
                elsif kaller.respond_to?("#{old_name}_#{current_locale_name}_#{suffix}")
                  current_locale_name
                else

--- a/test/dummy/app/controllers/dummy_controller.rb
+++ b/test/dummy/app/controllers/dummy_controller.rb
@@ -8,4 +8,7 @@ class DummyController < ActionController::Base
     # Pass
   end
 
+  def native
+    render :text => show_path
+  end
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -6,6 +6,7 @@ Dummy::Application.routes.draw do
     get 'show',   :to => 'dummy#show'
   end
 
+  get 'native', :to => 'dummy#native'
   root :to => 'dummy#dummy'
 
   mount DummyMountedApp.new => '/dummy_mounted_app'

--- a/test/integration/host_locales_test.rb
+++ b/test/integration/host_locales_test.rb
@@ -56,4 +56,17 @@ class HostLocalesTest < integration_test_suite_parent_class
     assert_response :success
   end
 
+  def test_generated_path
+    ## native es route on es com
+    host! 'www.testapp.es'
+    get '/native'
+    assert_equal '/mostrar', @response.body
+    assert_response :success
+
+    ## native ru route on ru com
+    host! 'ru.testapp.com'
+    get '/native'
+    assert_equal URI.escape('/показывать'), @response.body
+    assert_response :success
+  end
 end


### PR DESCRIPTION
This fixes #95, so that path generation under `host_locales` will not return with locale param. Instead of erroneously generating `/:locale/:path` it'll generate the expected `/:path`.

We've been running this in production since April and it have worked without any issues at all.