### PR TITLE
Permit named_params with suffix

### DIFF
--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -121,7 +121,10 @@ module RouteTranslator
     # segment is blank, begins with a ":" (param key) or "*" (wildcard),
     # the segment is returned untouched
     def self.translate_path_segment(segment, locale)
-      return segment if segment.blank? or segment.include?(":") or segment.starts_with?("(") or segment.starts_with?("*")
+      return segment if segment.blank?
+      named_param, hyphenized = segment.split('-'.freeze, 2) if segment.starts_with?(":".freeze)
+      return "#{named_param}-#{translate_path_segment(hyphenized.dup, locale)}" if hyphenized
+      return segment if segment.starts_with?("(".freeze) or segment.starts_with?("*".freeze) or segment.starts_with?(":".freeze)
 
       appended_part = segment.slice!(/(\()$/)
       match = TRANSLATABLE_SEGMENT.match(segment)[1] rescue nil

--- a/test/dummy/app/controllers/dummy_controller.rb
+++ b/test/dummy/app/controllers/dummy_controller.rb
@@ -12,4 +12,9 @@ class DummyController < ActionController::Base
     # Pass
   end
 
+  def suffix
+    #pass
+    render text: params[:id]
+  end
+
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -2,14 +2,16 @@ require File.join(Dummy::Application.root, 'dummy_mounted_app.rb')
 
 Dummy::Application.routes.draw do
   localized do
-    get 'dummy',  :to => 'dummy#dummy'
-    get 'show',   :to => 'dummy#show'
+    get 'dummy',  to: 'dummy#dummy'
+    get 'show',   to: 'dummy#show'
 
-    get 'optional(/:page)', :to => 'dummy#optional', :as => :optional
-    get 'prefixed_optional(/p-:page)', :to => 'dummy#prefixed_optional', :as => :prefixed_optional
+    get 'optional(/:page)', to: 'dummy#optional', as: :optional
+    get 'prefixed_optional(/p-:page)', to: 'dummy#prefixed_optional', as: :prefixed_optional
+
+    get ':id-suffix', to: 'dummy#suffix'
   end
 
-  root :to => 'dummy#dummy'
+  root to: 'dummy#dummy'
 
   mount DummyMountedApp.new => '/dummy_mounted_app'
 end

--- a/test/integration/generated_path_test.rb
+++ b/test/integration/generated_path_test.rb
@@ -54,4 +54,9 @@ class GeneratedPathTest < integration_test_suite_parent_class
     assert_tag :tag => "a", :attributes => { :href => "/prefixed_optional/p-12" }
   end
 
+  def test_path_translated_with_suffix
+    get '/10-suffix'
+    assert_response :success
+    assert_equal(response.body, "10")
+  end
 end


### PR DESCRIPTION
With rails we can have this kind of routes :

/:named_param-suffix-for-params

so this commit permit to translate suffix-for-params