### PR TITLE
Optional parameters with prefix breaks

### DIFF
--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -121,7 +121,7 @@ module RouteTranslator
     # segment is blank, begins with a ":" (param key) or "*" (wildcard),
     # the segment is returned untouched
     def self.translate_path_segment(segment, locale)
-      return segment if segment.blank? or segment.starts_with?(":") or segment.starts_with?("(") or segment.starts_with?("*")
+      return segment if segment.blank? or segment.include?(":") or segment.starts_with?("(") or segment.starts_with?("*")
 
       appended_part = segment.slice!(/(\()$/)
       match = TRANSLATABLE_SEGMENT.match(segment)[1] rescue nil

--- a/test/dummy/app/controllers/dummy_controller.rb
+++ b/test/dummy/app/controllers/dummy_controller.rb
@@ -8,4 +8,8 @@ class DummyController < ActionController::Base
     # Pass
   end
 
+  def optional
+    # Pass
+  end
+
 end

--- a/test/dummy/app/views/dummy/optional.html.erb
+++ b/test/dummy/app/views/dummy/optional.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "Optional [#{I18n.locale}]", optional_path(page: params[:page]) %>

--- a/test/dummy/app/views/dummy/prefixed_optional.html.erb
+++ b/test/dummy/app/views/dummy/prefixed_optional.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "Optional [#{I18n.locale}]", prefixed_optional_path(page: params[:page]) %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -4,6 +4,9 @@ Dummy::Application.routes.draw do
   localized do
     get 'dummy',  :to => 'dummy#dummy'
     get 'show',   :to => 'dummy#show'
+
+    get 'optional(/:page)', :to => 'dummy#optional', :as => :optional
+    get 'prefixed_optional(/p-:page)', :to => 'dummy#prefixed_optional', :as => :prefixed_optional
   end
 
   root :to => 'dummy#dummy'

--- a/test/integration/generated_path_test.rb
+++ b/test/integration/generated_path_test.rb
@@ -34,4 +34,24 @@ class GeneratedPathTest < integration_test_suite_parent_class
     assert_tag :tag => "a", :attributes => { :href => "/es/mostrar" }
   end
 
+  def test_with_optionals
+    get '/optional'
+    assert_response :success
+    assert_tag :tag => "a", :attributes => { :href => "/optional" }
+
+    get '/optional/12'
+    assert_response :success
+    assert_tag :tag => "a", :attributes => { :href => "/optional/12" }
+  end
+  
+  def test_with_prefixed_optionals
+    get '/prefixed_optional'
+    assert_response :success
+    assert_tag :tag => "a", :attributes => { :href => "/prefixed_optional" }
+
+    get '/prefixed_optional/p-12'
+    assert_response :success
+    assert_tag :tag => "a", :attributes => { :href => "/prefixed_optional/p-12" }
+  end
+
 end


### PR DESCRIPTION
Hi,

first of all; thanks for your awesome work on this gem!


The gem works fine with rails routes and optional parameters; e.g.

    /some(/:optional)

However, when I was porting over one of our applications, I noticed that something broke when using this gem (I was previously using another gem for route translation).

    /some(/page-:optional)

The issue lies in the **/page-** static prefix of the optional parameter. While this is fully supported in rails, the regex functions and translation routines in this gem, don't take the possible "prefix" into account.

If expanded the test from _a colon in the beginning_ of a segment to _somewhere_ in the segment. I wrote the necessary tests and they all passes again!

Would you please consider to merge this into your repository?

Please let me know if you have any questions, remarks or considerations!


Kind regards,


Stijn
