### PR TITLE
Mention available_locales config in README :book:

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ end
   For example if we have `/examples` and a translation is not provided for ES, a route helper of `examples_es` will not be created.
   Defaults to `false`.
   Useful when one uses this with a locale route constraint, so non-ES routes can 404 on a Spanish website.
-
+* **available_locales**
+  Use this to limit the locales for which URLs should be generated for. Accepts an array of strings or symbols.
 
 
 ### Host-based Locale


### PR DESCRIPTION
The `available_locales` setting wasn't mentioned in the README. Easy to find out by reading the source but somewhat cumbersome, so I added it.

Thanks for a very useful gem!