### PR TITLE
Generate correct route when a segment is preceded by a dot

### DIFF
--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -84,16 +84,16 @@ module RouteTranslator
     def self.translate_path(path, locale)
       new_path = path.dup
       final_optional_segments = new_path.slice!(%r{(\([^\/]+\))$})
-      translated_segments = new_path.split(%r{\/|\.}).map { |seg| translate_path_segment(seg, locale) }.select { |seg| !seg.blank? }
+      translated_segments = new_path.split('/').map do |seg|
+        seg.split('.').map { |phrase| translate_path_segment(phrase, locale) }.join('.')
+      end
+      translated_segments.select! { |seg| !seg.blank? }
 
       if display_locale?(locale) && !locale_param_present?(new_path)
         translated_segments.unshift(locale.to_s.downcase)
       end
 
-      joined_segments = translated_segments.inject do |memo, segment|
-        separator = segment == ':format' ? '.' : '/'
-        memo << separator << segment
-      end
+      joined_segments = translated_segments.join('/')
 
       "/#{joined_segments}#{final_optional_segments}".gsub(%r{\/\(\/}, '(/')
     end

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -298,6 +298,18 @@ class TranslateRoutesTest < ActionController::TestCase
     assert_routing '/people.xml', controller: 'people', action: 'index', format: 'xml', locale: 'en'
   end
 
+  def test_routes_with_dot
+    draw_routes do
+      localized do
+        get 'people/.:name', to: 'people#index'
+        get 'products.:name', to: 'products#index'
+      end
+    end
+
+    assert_routing '/people/.john', controller: 'people', action: 'index', locale: 'en', name: 'john'
+    assert_routing '/products.book', controller: 'products', action: 'index', locale: 'en', name: 'book'
+  end
+
   def test_i18n_based_translations_setting_locales
     draw_routes do
       localized do


### PR DESCRIPTION
#58 Solved the issue with `people.:format` but it didn't work for something like `people:.name` or `people/.:name`.

This solves the issue for every situation.