### PR TITLE
support custom locale path segments, i.e. /uk/en/widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ end
   Useful when one uses this with a locale route constraint, so non-ES routes can 404 on a Spanish website.
 * **available_locales**
   Use this to limit the locales for which URLs should be generated for. Accepts an array of strings or symbols.
+* **locale_segment_proc**
+  The locale segment of the url will by default be `locale.to_s.downcase`
+  You can supply your own mechanism via a Proc that takes `locale` as an argument, e.g. `config.locale_segment_proc = ->(locale) { locale.to_s.upcase }`
 
 
 ### Host-based Locale

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -12,7 +12,7 @@ module RouteTranslator
   Configuration = Struct.new(:force_locale, :hide_locale,
                              :generate_unlocalized_routes, :locale_param_key,
                              :generate_unnamed_unlocalized_routes, :available_locales,
-                             :host_locales, :disable_fallback)
+                             :host_locales, :disable_fallback, :locale_segment_proc)
 
   class << self
     private
@@ -37,6 +37,7 @@ module RouteTranslator
     @config.host_locales                        ||= ActiveSupport::OrderedHash.new
     @config.available_locales                   ||= []
     @config.disable_fallback                    ||= false
+    @config.locale_segment_proc                 ||= nil
     yield @config if block
     resolve_host_locale_config_conflicts unless @config.host_locales.empty?
     @config

--- a/lib/route_translator/translator/path.rb
+++ b/lib/route_translator/translator/path.rb
@@ -23,6 +23,16 @@ module RouteTranslator
         def locale_param_present?(path)
           path.split('/').include? ":#{RouteTranslator.locale_param_key}"
         end
+
+        def locale_segment(locale)
+          if RouteTranslator.config.locale_segment_proc
+            locale_segment_proc = RouteTranslator.config.locale_segment_proc
+
+            locale_segment_proc.to_proc.call(locale)
+          else
+            locale.to_s.downcase
+          end
+        end
       end
 
       module_function
@@ -37,7 +47,7 @@ module RouteTranslator
         translated_segments.reject!(&:empty?)
 
         if display_locale?(locale) && !locale_param_present?(new_path)
-          translated_segments.unshift(locale.to_s.downcase)
+          translated_segments.unshift(locale_segment(locale))
         end
 
         joined_segments = translated_segments.join('/')

--- a/test/dummy/config/locales/all.yml
+++ b/test/dummy/config/locales/all.yml
@@ -13,3 +13,8 @@ ru:
   routes:
     dummy: манекен
     show: показывать
+
+de-AT:
+  routes:
+    dummy: Attrappe
+    show: anzeigen

--- a/test/integration/generated_path_test.rb
+++ b/test/integration/generated_path_test.rb
@@ -4,6 +4,14 @@ require File.expand_path('../../test_helper', __FILE__)
 class GeneratedPathTest < integration_test_suite_parent_class
   include RouteTranslator::ConfigurationHelper
 
+  def setup
+    setup_config
+  end
+
+  def teardown
+    teardown_config
+  end
+
   def test_path_generated
     get '/show'
     assert_response :success

--- a/test/integration/locale_path_segment_test.rb
+++ b/test/integration/locale_path_segment_test.rb
@@ -1,0 +1,60 @@
+# coding: utf-8
+require File.expand_path('../../test_helper', __FILE__)
+
+class LocaleSegmentProcTest < integration_test_suite_parent_class
+  include RouteTranslator::ConfigurationHelper
+
+  def setup
+    setup_config
+  end
+
+  def teardown
+    teardown_config
+  end
+
+  def test_recognize_with_locale_segment_proc
+    config_locale_segment_proc ->(locale) { locale.to_s.upcase }
+    Rails.application.reload_routes!
+
+    get '/DE-AT/Attrappe' # dummy
+    assert_response :success
+  end
+
+  def test_recognize_without_locale_segment_proc
+    config_locale_segment_proc false
+    Rails.application.reload_routes!
+
+    # downcase is default
+    get '/de-at/Attrappe' # dummy
+    assert_response :success
+  end
+
+  def test_generate_with_locale_segment_proc
+    config_locale_segment_proc ->(locale) { locale.to_s }
+    Rails.application.reload_routes!
+
+    # not the default downcase
+    get '/de-AT/anzeigen' # show
+    assert_response :success
+    assert_tag tag: 'a', attributes: { href: '/de-AT/anzeigen' }
+  end
+
+  def test_generate_without_locale_segment_proc
+    config_locale_segment_proc false
+    Rails.application.reload_routes!
+
+    get '/de-at/anzeigen' # show
+    assert_response :success
+    assert_tag tag: 'a', attributes: { href: '/de-at/anzeigen' }
+  end
+
+  # IKEA style "www.ikea.com/gb/en"
+  def test_helper_with_locale_segment_proc
+    config_locale_segment_proc ->(locale) { locale.to_s.downcase.split('-').reverse.join('/') }
+    Rails.application.reload_routes!
+
+    I18n.with_locale(:'de-AT') do
+      assert_equal '/at/de/anzeigen', show_path
+    end
+  end
+end

--- a/test/locales/routes.yml
+++ b/test/locales/routes.yml
@@ -9,5 +9,12 @@ ru:
   routes:
     people: люди
 
+de-AT:
+  routes:
+    people: Menschen
+    products: Produkten
+    tr_param: tr_parameter
+    blank: ""
+
 en:
   m: m #Adding this here just to have en in I18n.available_locales

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -34,6 +34,7 @@ class TranslateRoutesTest < ActionController::TestCase
 
     assert_routing '/', controller: 'people', action: 'index', locale: 'en'
     assert_routing '/es', controller: 'people', action: 'index', locale: 'es'
+    assert_routing '/de-at', controller: 'people', action: 'index', locale: 'de-AT'
   end
 
   def test_params

--- a/test/support/configuration_helper.rb
+++ b/test/support/configuration_helper.rb
@@ -6,6 +6,9 @@ module RouteTranslator
       config_generate_unlocalized_routes false
       config_generate_unnamed_unlocalized_routes false
       config_host_locales
+      config_available_locales []
+      config_disable_fallback false
+      config_locale_segment_proc false
 
       config_default_locale_settings :en
     end
@@ -43,6 +46,10 @@ module RouteTranslator
 
     def config_disable_fallback(boolean)
       RouteTranslator.config.disable_fallback = boolean
+    end
+
+    def config_locale_segment_proc(a_proc)
+      RouteTranslator.config.locale_segment_proc = a_proc
     end
   end
 end


### PR DESCRIPTION
(originally PR #137)
I have a requirement to use "IKEA-style" locale segments that look like:
`/<region>/<language>` e.g. `/gb/en/foo/bar` for the locale: `en-GB`

I've created this PR to allow anyone to supply their own Proc for generating the locale segment of the path.

For my needs I can do the following:
```ruby
RouteTranslator.config do |config|
  config.locale_segment_proc = ->(locale) { locale.to_s.downcase.split('-').reverse.join('/') }
end
```