### PR TITLE
Add an ability to translate controllers with namespaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,37 @@ describe 'GET index' do
 end
 ```
 
+### Translations for similar routes with different namespaces
+
+If you have routes that (partially) share names in one locale, but must be translated differently in another locale, for example:
+
+```ruby
+  get 'people/favourites', to: 'people/products#favourites'
+  get 'favourites',        to: 'products#favourites'
+```
+
+Then it is possible to provide different translations for common parts of those routes by
+scoping translations by a controller's namespace:
+
+```yml
+es:
+  routes:
+    favourites: favoritos
+    controllers:
+      people:
+        products:
+          favourites: fans
+```
+
+Routes will be translated as in:
+
+```
+people_products_favourites_es GET  /people/products/fans(.:format)       people/products#favourites {:locale=>"es"}
+       products_favourites_es GET  /products/favoritos(.:format)         products#favourites {:locale=>"es"}
+```
+
+The gem will lookup translations under `controllers` scope first and then lookup translations under `routes` scope.
+
 ## Contributing
 
 Please read through our [contributing guidelines](CONTRIBUTING.md). Included are directions for opening issues, coding standards, and notes on development.

--- a/lib/route_translator/extensions/route_set.rb
+++ b/lib/route_translator/extensions/route_set.rb
@@ -4,7 +4,9 @@ module ActionDispatch
   module Routing
     class RouteSet
       def add_localized_route(mapping, path_ast, name, anchor, scope, path, controller, default_action, to, via, formatted, options_constraints, options)
-        RouteTranslator::Translator.translations_for(self, path, name, options_constraints, options) do |translated_name, translated_path, translated_options_constraints, translated_options|
+        route = RouteTranslator::Route.new(self, path, name, options_constraints, options, mapping)
+
+        RouteTranslator::Translator.translations_for(route) do |translated_name, translated_path, translated_options_constraints, translated_options|
           translated_path_ast = ::ActionDispatch::Journey::Parser.parse(translated_path)
           translated_mapping  = ::ActionDispatch::Routing::Mapper::Mapping.build(scope, self, translated_path_ast, controller, default_action, to, via, formatted, translated_options_constraints, anchor, translated_options)
 

--- a/lib/route_translator/route.rb
+++ b/lib/route_translator/route.rb
@@ -1,0 +1,18 @@
+module RouteTranslator
+  class Route
+    attr_reader :route_set, :path, :name, :options_constraints, :options, :mapping
+
+    def initialize(route_set, path, name, options_constraints, options, mapping)
+      @route_set           = route_set
+      @path                = path
+      @name                = name
+      @options_constraints = options_constraints
+      @options             = options
+      @mapping             = mapping
+    end
+
+    def scope
+      @scope ||= [:routes, :controllers].concat mapping.defaults[:controller].split('/').map(&:to_sym)
+    end
+  end
+end

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -2,11 +2,24 @@
 
 require File.expand_path('../translator/route_helpers', __FILE__)
 require File.expand_path('../translator/path', __FILE__)
+require File.expand_path('../route', __FILE__)
 
 module RouteTranslator
   module Translator
     class << self
       private
+
+      def translated_attributes(locale, translated_path, route)
+        translated_options_constraints = route.options_constraints.dup
+        translated_options             = route.options.dup
+
+        translated_options_constraints[RouteTranslator.locale_param_key] = locale.to_s
+        translated_options[RouteTranslator.locale_param_key]             = locale.to_s.gsub('native_', '') unless translated_options.include?(RouteTranslator.locale_param_key)
+
+        translated_name = translate_name(route.name, locale, route.route_set.named_routes.names)
+
+        [translated_name, translated_path, translated_options_constraints, translated_options]
+      end
 
       def available_locales
         locales = RouteTranslator.available_locales
@@ -35,26 +48,18 @@ module RouteTranslator
 
     module_function
 
-    def translations_for(route_set, path, name, options_constraints, options)
-      RouteTranslator::Translator::RouteHelpers.add name, route_set.named_routes
+    def translations_for(route)
+      RouteTranslator::Translator::RouteHelpers.add route.name, route.route_set.named_routes
 
       available_locales.each do |locale|
         begin
-          translated_path = RouteTranslator::Translator::Path.translate(path, locale)
+          translated_path = RouteTranslator::Translator::Path.translate(route.path, locale, route.scope)
         rescue I18n::MissingTranslationData => e
           raise e unless RouteTranslator.config.disable_fallback
           next
         end
 
-        translated_options_constraints = options_constraints.dup
-        translated_options             = options.dup
-
-        translated_options_constraints[RouteTranslator.locale_param_key] = locale.to_s
-        translated_options[RouteTranslator.locale_param_key]             = locale.to_s.gsub('native_', '') unless translated_options.include?(RouteTranslator.locale_param_key)
-
-        translated_name = translate_name(name, locale, route_set.named_routes.names)
-
-        yield translated_name, translated_path, translated_options_constraints, translated_options
+        yield translated_attributes(locale, translated_path, route)
       end
     end
 

--- a/lib/route_translator/translator/path.rb
+++ b/lib/route_translator/translator/path.rb
@@ -38,11 +38,11 @@ module RouteTranslator
       module_function
 
       # Translates a path and adds the locale prefix.
-      def translate(path, locale)
+      def translate(path, locale, scope)
         new_path = path.dup
         final_optional_segments = new_path.slice!(%r{(\([^\/]+\))$})
         translated_segments = new_path.split('/').map do |seg|
-          seg.split('.').map { |phrase| Segment.translate(phrase, locale) }.join('.')
+          seg.split('.').map { |phrase| Segment.translate(phrase, locale, scope) }.join('.')
         end
         translated_segments.reject!(&:empty?)
 

--- a/lib/route_translator/translator/path/segment.rb
+++ b/lib/route_translator/translator/path/segment.rb
@@ -16,17 +16,13 @@ module RouteTranslator
           def translate_string(str, locale, scope)
             locale = locale.to_s.gsub('native_', '')
             handler = proc { |exception| exception }
-            default_opts = { scope: scope, locale: locale }
+            opts = { scope: scope, locale: locale }
 
-            opts = default_opts.merge(exception_handler: handler)
-            res = I18n.translate(str, opts)
-
-            if res.is_a?(I18n::MissingTranslation) || res.is_a?(Hash)
-              opts = default_opts
-                     .merge(scope: :routes)
-                     .merge(fallback_options(str, locale))
-              res = I18n.translate(str, opts)
-            end
+            res = if I18n.translate(str, opts.merge(exception_handler: handler)).is_a?(I18n::MissingTranslation)
+                    I18n.translate(str, opts.merge(scope: :routes).merge(fallback_options(str, locale)).merge(exception_handler: nil))
+                  else
+                    I18n.translate(str, opts.merge(exception_handler: handler))
+                  end
 
             URI.escape(res)
           end

--- a/lib/route_translator/translator/path/segment.rb
+++ b/lib/route_translator/translator/path/segment.rb
@@ -5,15 +5,29 @@ module RouteTranslator
         class << self
           private
 
-          def translate_string(str, locale)
-            locale = locale.to_s.gsub('native_', '')
-            opts = { scope: :routes, locale: locale }
+          def fallback_options(str, locale)
             if RouteTranslator.config.disable_fallback && locale.to_s != I18n.default_locale.to_s
-              opts[:fallback] = true
+              { fallback: true }
             else
-              opts[:default] = str
+              { default: str }
             end
+          end
+
+          def translate_string(str, locale, scope)
+            locale = locale.to_s.gsub('native_', '')
+            handler = proc { |exception| exception }
+            default_opts = { scope: scope, locale: locale }
+
+            opts = default_opts.merge(exception_handler: handler)
             res = I18n.translate(str, opts)
+
+            if res.is_a?(I18n::MissingTranslation) || res.is_a?(Hash)
+              opts = default_opts
+                     .merge(scope: :routes)
+                     .merge(fallback_options(str, locale))
+              res = I18n.translate(str, opts)
+            end
+
             URI.escape(res)
           end
         end
@@ -26,16 +40,16 @@ module RouteTranslator
         # "people(.:format)", only "people" will be translated.
         # If there is no translation, the path segment is blank, begins with a
         # ":" (param key) or "*" (wildcard), the segment is returned untouched.
-        def translate(segment, locale)
+        def translate(segment, locale, scope)
           return segment if segment.empty?
           named_param, hyphenized = segment.split('-'.freeze, 2) if segment.starts_with?(':'.freeze)
-          return "#{named_param}-#{translate(hyphenized.dup, locale)}" if hyphenized
+          return "#{named_param}-#{translate(hyphenized.dup, locale, scope)}" if hyphenized
           return segment if segment.starts_with?('('.freeze) || segment.starts_with?('*'.freeze) || segment.include?(':'.freeze)
 
           appended_part = segment.slice!(/(\()$/)
           match = TRANSLATABLE_SEGMENT.match(segment)[1] if TRANSLATABLE_SEGMENT.match(segment)
 
-          (translate_string(match, locale) || segment) + appended_part.to_s
+          (translate_string(match, locale, scope) || segment) + appended_part.to_s
         end
       end
     end

--- a/test/locales/routes.yml
+++ b/test/locales/routes.yml
@@ -3,11 +3,21 @@ es:
     people: gente
     products: productos
     tr_param: tr_parametro
+    favourites: favoritos
     blank: ""
+    controllers:
+      people:
+        products:
+          favourites: fans
 
 ru:
   routes:
     people: люди
+    favourites: избранное
+    controllers:
+      people:
+        products:
+          favourites: кандидаты
 
 de-AT:
   routes:

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -7,6 +7,11 @@ end
 class ProductsController < ActionController::Base
 end
 
+module People
+  class ProductsController < ActionController::Base
+  end
+end
+
 class TranslateRoutesTest < ActionController::TestCase
   include ActionDispatch::Assertions::RoutingAssertions
   include RouteTranslator::AssertionHelper
@@ -125,6 +130,22 @@ class TranslateRoutesTest < ActionController::TestCase
     assert_routing '/productos', controller: 'products', action: 'index', locale: 'es'
     assert_routing({ path: '/productos/1', method: 'GET' }, controller: 'products', action: 'show', id: '1', locale: 'es')
     assert_unrecognized_route({ path: '/productos/1', method: 'PUT' }, controller: 'products', action: 'update', id: '1', locale: 'es')
+  end
+
+  def test_namespaced_controllers
+    config_default_locale_settings 'es'
+
+    draw_routes do
+      localized do
+        get 'people/favourites', to: 'people/products#favourites'
+        get 'favourites',        to: 'products#favourites'
+      end
+    end
+
+    assert_routing '/gente/fans', controller: 'people/products', action: 'favourites', locale: 'es'
+    assert_routing '/favoritos', controller: 'products', action: 'favourites', locale: 'es'
+    assert_routing URI.escape('/ru/люди/кандидаты'), controller: 'people/products', action: 'favourites', locale: 'ru'
+    assert_routing URI.escape('/ru/избранное'), controller: 'products', action: 'favourites', locale: 'ru'
   end
 
   def test_unnamed_root_route_without_prefix


### PR DESCRIPTION
This patch adds a new feature: ability to provide different translations for routes with different namespaces.
Translations for specific namespaces/controllers should be placed under:

``` yaml
routes:
   controllers:
```
