### PR TITLE
Fix issue with callable constraints

### DIFF
--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -46,7 +46,7 @@ module RouteTranslator
           next
         end
 
-        translated_options_constraints = options_constraints.dup
+        translated_options_constraints = options_constraints.respond_to?(:call) ? {} : options_constraints.dup
         translated_options             = options.dup
 
         translated_options_constraints[RouteTranslator.locale_param_key] = locale.to_s

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -78,6 +78,16 @@ class TranslateRoutesTest < ActionController::TestCase
     assert_routing '/es/productos/a', controller: 'products', action: 'index', locale: 'es', tr_param: 'a'
   end
 
+  def test_block_constraints_dont_fail
+    assert_nothing_raised NoMethodError do
+      draw_routes do
+        localized do
+          get 'products/:tr_param', to: 'products#index', constraints: -> { true }
+        end
+      end
+    end
+  end
+
   def test_wildcards_dont_get_translated
     draw_routes do
       localized do


### PR DESCRIPTION
When a constraint is callable it will fail with NoMethodError due to
`[]=` not being implemented.  Instead we return an empty hash.