### PR TITLE
Retain value of options_constraints if callable

### DIFF
--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -46,11 +46,14 @@ module RouteTranslator
           next
         end
 
-        translated_options_constraints = options_constraints.respond_to?(:call) ? {} : options_constraints.dup
+        translated_options_constraints = options_constraints.dup
         translated_options             = options.dup
 
-        translated_options_constraints[RouteTranslator.locale_param_key] = locale.to_s
-        translated_options[RouteTranslator.locale_param_key]             = locale.to_s.gsub('native_', '') unless translated_options.include?(RouteTranslator.locale_param_key)
+        if translated_options_constraints.respond_to?(:[]=)
+          translated_options_constraints[RouteTranslator.locale_param_key] = locale.to_s
+        end
+
+        translated_options[RouteTranslator.locale_param_key] = locale.to_s.gsub('native_', '') unless translated_options.include?(RouteTranslator.locale_param_key)
 
         translated_name = translate_name(name, locale, route_set.named_routes.names)
 

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -88,6 +88,17 @@ class TranslateRoutesTest < ActionController::TestCase
     end
   end
 
+  def test_block_constraints_remain_obeyed
+    draw_routes do
+      localized do
+        get 'products', to: 'zambonis#index', constraints: ->(_req) { false }
+        get 'products', to: 'products#index', constraints: ->(_req) { true }
+      end
+    end
+
+    assert_routing '/products', controller: 'products', action: 'index', locale: 'en'
+  end
+
   def test_wildcards_dont_get_translated
     draw_routes do
       localized do


### PR DESCRIPTION
When changing options_constraints to an empty hash for #translations_for
it overrides the callable preventing the constraint from working in
rails. Instead of overriding the value we should only modify it if the
value responds to `[]=`.