### PR TITLE
Localize mounted helper

### DIFF
--- a/lib/route_translator/extensions/mapper.rb
+++ b/lib/route_translator/extensions/mapper.rb
@@ -41,6 +41,18 @@ module ActionDispatch
           @set.add_route(mapping, ast, as, anchor)
         end
       end
+
+      private
+
+      def define_generate_prefix(app, name)
+        if @localized
+          RouteTranslator::Translator.available_locales.each do |locale|
+            super(app, "#{name}_#{locale.to_s.underscore}")
+          end
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/route_translator/extensions/mapper.rb
+++ b/lib/route_translator/extensions/mapper.rb
@@ -45,12 +45,10 @@ module ActionDispatch
       private
 
       def define_generate_prefix(app, name)
-        if @localized
-          RouteTranslator::Translator.available_locales.each do |locale|
-            super(app, "#{name}_#{locale.to_s.underscore}")
-          end
-        else
-          super
+        return super unless @localized
+
+        RouteTranslator::Translator.available_locales.each do |locale|
+          super(app, "#{name}_#{locale.to_s.underscore}")
         end
       end
     end

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -6,16 +6,6 @@ require File.expand_path('../translator/path', __FILE__)
 module RouteTranslator
   module Translator
     class << self
-      def available_locales
-        locales = RouteTranslator.available_locales
-        locales.concat(RouteTranslator.native_locales) if RouteTranslator.native_locales.present?
-        # Make sure the default locale is translated in last place to avoid
-        # problems with wildcards when default locale is omitted in paths. The
-        # default routes will catch all paths like wildcard if it is translated first.
-        locales.delete I18n.default_locale
-        locales.push I18n.default_locale
-      end
-
       private
 
       def host_locales_option?
@@ -34,6 +24,16 @@ module RouteTranslator
     end
 
     module_function
+
+    def available_locales
+      locales = RouteTranslator.available_locales
+      locales.concat(RouteTranslator.native_locales) if RouteTranslator.native_locales.present?
+      # Make sure the default locale is translated in last place to avoid
+      # problems with wildcards when default locale is omitted in paths. The
+      # default routes will catch all paths like wildcard if it is translated first.
+      locales.delete I18n.default_locale
+      locales.push I18n.default_locale
+    end
 
     def translations_for(route_set, path, name, options_constraints, options)
       RouteTranslator::Translator::RouteHelpers.add name, route_set.named_routes

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -6,8 +6,6 @@ require File.expand_path('../translator/path', __FILE__)
 module RouteTranslator
   module Translator
     class << self
-      private
-
       def available_locales
         locales = RouteTranslator.available_locales
         locales.concat(RouteTranslator.native_locales) if RouteTranslator.native_locales.present?
@@ -17,6 +15,8 @@ module RouteTranslator
         locales.delete I18n.default_locale
         locales.push I18n.default_locale
       end
+
+      private
 
       def host_locales_option?
         RouteTranslator.config.host_locales.present?

--- a/test/dummy/app/controllers/blorgh/posts_controller.rb
+++ b/test/dummy/app/controllers/blorgh/posts_controller.rb
@@ -1,0 +1,5 @@
+module Blorgh
+  class PostsController < ActionController::Base
+    def index; render text: I18n.locale end
+  end
+end

--- a/test/dummy/app/controllers/blorgh/posts_controller.rb
+++ b/test/dummy/app/controllers/blorgh/posts_controller.rb
@@ -1,5 +1,7 @@
 module Blorgh
   class PostsController < ActionController::Base
-    def index; render text: I18n.locale end
+    def index
+      render text: I18n.locale
+    end
   end
 end

--- a/test/dummy/app/controllers/dummy_controller.rb
+++ b/test/dummy/app/controllers/dummy_controller.rb
@@ -19,4 +19,8 @@ class DummyController < ActionController::Base
   def suffix
     render text: params[:id]
   end
+
+  def engine
+    render text: blorgh.posts_path
+  end
 end

--- a/test/dummy/app/controllers/dummy_controller.rb
+++ b/test/dummy/app/controllers/dummy_controller.rb
@@ -20,7 +20,11 @@ class DummyController < ActionController::Base
     render text: params[:id]
   end
 
-  def engine
+  def engine_es
     render text: blorgh_es.posts_path
+  end
+
+  def engine
+    render text: blorgh.posts_path
   end
 end

--- a/test/dummy/app/controllers/dummy_controller.rb
+++ b/test/dummy/app/controllers/dummy_controller.rb
@@ -21,6 +21,6 @@ class DummyController < ActionController::Base
   end
 
   def engine
-    render text: blorgh.posts_path
+    render text: blorgh_es.posts_path
   end
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -6,7 +6,6 @@ begin
 rescue LoadError
   ''
 end
-
 require 'route_translator'
 
 module Dummy
@@ -17,3 +16,14 @@ module Dummy
     config.eager_load = false
   end
 end
+
+module Blorgh
+  class Engine < ::Rails::Engine
+    isolate_namespace Blorgh
+
+    routes.draw do
+      resources :posts, only: :index
+    end
+  end
+end
+

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -6,6 +6,7 @@ begin
 rescue LoadError
   ''
 end
+
 require 'route_translator'
 
 module Dummy
@@ -26,4 +27,3 @@ module Blorgh
     end
   end
 end
-

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -17,6 +17,7 @@ Dummy::Application.routes.draw do
 
   get 'partial_caching', to: 'dummy#partial_caching'
   get 'native', to: 'dummy#native'
+  get 'engine_es', to: 'dummy#engine_es'
   get 'engine', to: 'dummy#engine'
   root to: 'dummy#dummy'
 
@@ -25,4 +26,5 @@ Dummy::Application.routes.draw do
   localized do
     mount Blorgh::Engine, at: '/blorgh'
   end
+  mount Blorgh::Engine, at: '/blorgh'
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -4,7 +4,6 @@ Blorgh::Engine.routes.draw do
   resources :posts, only: :index
 end
 
-
 Dummy::Application.routes.draw do
   localized do
     get 'dummy',  to: 'dummy#dummy'

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,5 +1,10 @@
 require File.join(Dummy::Application.root, 'dummy_mounted_app.rb')
 
+Blorgh::Engine.routes.draw do
+  resources :posts, only: :index
+end
+
+
 Dummy::Application.routes.draw do
   localized do
     get 'dummy',  to: 'dummy#dummy'
@@ -13,7 +18,12 @@ Dummy::Application.routes.draw do
 
   get 'partial_caching', to: 'dummy#partial_caching'
   get 'native', to: 'dummy#native'
+  get 'engine', to: 'dummy#engine'
   root to: 'dummy#dummy'
 
   mount DummyMountedApp.new => '/dummy_mounted_app'
+
+  localized do
+    mount Blorgh::Engine, at: '/blorgh'
+  end
 end

--- a/test/integration/generated_path_test.rb
+++ b/test/integration/generated_path_test.rb
@@ -72,6 +72,15 @@ class GeneratedPathTest < ActionDispatch::IntegrationTest
     config_default_locale_settings 'es'
     config_generate_unlocalized_routes false
 
+    get '/engine_es'
+    assert_response :success
+    assert_equal(response.body, '/blorgh/posts')
+  end
+
+  def test_with_engine_outside_localized_block
+    config_default_locale_settings 'es'
+    config_generate_unlocalized_routes false
+
     get '/engine'
     assert_response :success
     assert_equal(response.body, '/blorgh/posts')

--- a/test/integration/generated_path_test.rb
+++ b/test/integration/generated_path_test.rb
@@ -74,6 +74,6 @@ class GeneratedPathTest < ActionDispatch::IntegrationTest
 
     get '/engine'
     assert_response :success
-    assert_equal(response.body, '/es/blorgh/posts')
+    assert_equal(response.body, '/blorgh/posts')
   end
 end

--- a/test/integration/generated_path_test.rb
+++ b/test/integration/generated_path_test.rb
@@ -72,7 +72,7 @@ class GeneratedPathTest < ActionDispatch::IntegrationTest
     config_default_locale_settings 'es'
     config_generate_unlocalized_routes false
 
-    get '/es/engine'
+    get '/engine'
     assert_response :success
     assert_equal(response.body, '/es/blorgh/posts')
   end

--- a/test/integration/generated_path_test.rb
+++ b/test/integration/generated_path_test.rb
@@ -67,4 +67,13 @@ class GeneratedPathTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal(response.body, '10')
   end
+
+  def test_with_engine_inside_localized_block
+    config_default_locale_settings 'es'
+    config_generate_unlocalized_routes false
+
+    get '/es/engine'
+    assert_response :success
+    assert_equal(response.body, '/es/blorgh/posts')
+  end
 end


### PR DESCRIPTION
close https://github.com/enriclluelles/route_translator/issues/123

For following routes,

```rb
localized do
  mount Blorgh::Engine, at: '/blorgh'
end
```

this patch defines `blorgh_en`, `blorgh_es`, `blorgh_ru`, ... to `Rails.application.routes.mounted_helpers`, instead of broken `blorgh`.

Even with this fix, only one of `blorgh_en`, `blorgh_es`, ... works because of https://github.com/rails/rails/issues/27352. But it's Rails' bug and I think route_translator should have this change.

What do you think? @tagliala