### PR TITLE
Add an ability to translate controllers with namespaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,38 @@ If `host_locales` option is set, the following options will be forced (even if y
 This is to avoid odd behaviour brought about by route conflicts and because `host_locales` forces and hides the host-locale dynamically.
 
 
+### Translations for similar routes with different namespaces
+
+If you have routes that (partially) share names in one locale, but must be translated differently in another locale, for example:
+
+```ruby
+get 'people/favourites', to: 'people/products#favourites'
+get 'favourites',        to: 'products#favourites'
+```
+
+Then it is possible to provide different translations for common parts of those routes by
+scoping translations by a controller's namespace:
+
+```yml
+es:
+  routes:
+    favourites: favoritos
+    controllers:
+      people:
+        products:
+          favourites: fans
+```
+
+Routes will be translated as in:
+
+```
+people_products_favourites_es GET  /people/products/fans(.:format)       people/products#favourites {:locale=>"es"}
+       products_favourites_es GET  /products/favoritos(.:format)         products#favourites {:locale=>"es"}
+```
+
+The gem will lookup translations under `controllers` scope first and then lookup translations under `routes` scope.
+
+
 
 ## Testing
 Testing your controllers with routes-translator is easy, just add a locale parameter for your localized routes. Otherwise, an ActionController::UrlGenerationError will raise.

--- a/lib/route_translator/extensions/route_set.rb
+++ b/lib/route_translator/extensions/route_set.rb
@@ -4,7 +4,9 @@ module ActionDispatch
   module Routing
     class RouteSet
       def add_localized_route(mapping, path_ast, name, anchor, scope, path, controller, default_action, to, via, formatted, options_constraints, options)
-        RouteTranslator::Translator.translations_for(self, path, name, options_constraints, options) do |translated_name, translated_path, translated_options_constraints, translated_options|
+        route = RouteTranslator::Route.new(self, path, name, options_constraints, options, mapping)
+
+        RouteTranslator::Translator.translations_for(route) do |translated_name, translated_path, translated_options_constraints, translated_options|
           translated_path_ast = ::ActionDispatch::Journey::Parser.parse(translated_path)
           translated_mapping  = ::ActionDispatch::Routing::Mapper::Mapping.build(scope, self, translated_path_ast, controller, default_action, to, via, formatted, translated_options_constraints, anchor, translated_options)
 

--- a/lib/route_translator/route.rb
+++ b/lib/route_translator/route.rb
@@ -1,0 +1,23 @@
+module RouteTranslator
+  class Route
+    attr_reader :route_set, :path, :name, :options_constraints, :options, :mapping
+
+    def initialize(route_set, path, name, options_constraints, options, mapping)
+      @route_set           = route_set
+      @path                = path
+      @name                = name
+      @options_constraints = options_constraints
+      @options             = options
+      @mapping             = mapping
+    end
+
+    def scope
+      @scope ||=
+        if mapping.defaults[:controller]
+          [:routes, :controllers].concat mapping.defaults[:controller].split('/').map(&:to_sym)
+        else
+          [:routes, :controllers]
+        end
+    end
+  end
+end

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -2,6 +2,7 @@
 
 require File.expand_path('../translator/route_helpers', __FILE__)
 require File.expand_path('../translator/path', __FILE__)
+require File.expand_path('../route', __FILE__)
 
 module RouteTranslator
   module Translator
@@ -39,8 +40,8 @@ module RouteTranslator
         translated_options_constraints
       end
 
-      def translate_path(path, locale)
-        RouteTranslator::Translator::Path.translate(path, locale)
+      def translate_path(path, locale, scope)
+        RouteTranslator::Translator::Path.translate(path, locale, scope)
       rescue I18n::MissingTranslationData => e
         raise e unless RouteTranslator.config.disable_fallback
       end
@@ -58,16 +59,16 @@ module RouteTranslator
       locales.push I18n.default_locale
     end
 
-    def translations_for(route_set, path, name, options_constraints, options)
-      RouteTranslator::Translator::RouteHelpers.add name, route_set.named_routes
+    def translations_for(route)
+      RouteTranslator::Translator::RouteHelpers.add route.name, route.route_set.named_routes
 
       available_locales.each do |locale|
-        translated_path = translate_path(path, locale)
+        translated_path = translate_path(route.path, locale, route.scope)
         next unless translated_path
 
-        translated_name                = translate_name(name, locale, route_set.named_routes.names)
-        translated_options_constraints = translate_options_constraints(options_constraints, locale)
-        translated_options             = translate_options(options, locale)
+        translated_name                = translate_name(route.name, locale, route.route_set.named_routes.names)
+        translated_options_constraints = translate_options_constraints(route.options_constraints, locale)
+        translated_options             = translate_options(route.options, locale)
 
         yield translated_name, translated_path, translated_options_constraints, translated_options
       end

--- a/lib/route_translator/translator/path.rb
+++ b/lib/route_translator/translator/path.rb
@@ -38,11 +38,11 @@ module RouteTranslator
       module_function
 
       # Translates a path and adds the locale prefix.
-      def translate(path, locale)
+      def translate(path, locale, scope)
         new_path = path.dup
         final_optional_segments = new_path.slice!(%r{(\([^\/]+\))$})
         translated_segments = new_path.split('/').map do |seg|
-          seg.split('.').map { |phrase| Segment.translate(phrase, locale) }.join('.')
+          seg.split('.').map { |phrase| Segment.translate(phrase, locale, scope) }.join('.')
         end
         translated_segments.reject!(&:empty?)
 

--- a/test/locales/routes.yml
+++ b/test/locales/routes.yml
@@ -3,11 +3,21 @@ es:
     people: gente
     products: productos
     tr_param: tr_parametro
+    favourites: favoritos
     blank: ""
+    controllers:
+      people:
+        products:
+          favourites: fans
 
 ru:
   routes:
     people: люди
+    favourites: избранное
+    controllers:
+      people:
+        products:
+          favourites: кандидаты
 
 de-AT:
   routes:

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -7,6 +7,11 @@ end
 class ProductsController < ActionController::Base
 end
 
+module People
+  class ProductsController < ActionController::Base
+  end
+end
+
 class TranslateRoutesTest < ActionController::TestCase
   include ActionDispatch::Assertions::RoutingAssertions
   include RouteTranslator::AssertionHelper
@@ -146,6 +151,22 @@ class TranslateRoutesTest < ActionController::TestCase
     assert_routing '/productos', controller: 'products', action: 'index', locale: 'es'
     assert_routing({ path: '/productos/1', method: 'GET' }, controller: 'products', action: 'show', id: '1', locale: 'es')
     assert_unrecognized_route({ path: '/productos/1', method: 'PUT' }, controller: 'products', action: 'update', id: '1', locale: 'es')
+  end
+
+  def test_namespaced_controllers
+    config_default_locale_settings 'es'
+
+    draw_routes do
+      localized do
+        get 'people/favourites', to: 'people/products#favourites'
+        get 'favourites',        to: 'products#favourites'
+      end
+    end
+
+    assert_routing '/gente/fans', controller: 'people/products', action: 'favourites', locale: 'es'
+    assert_routing '/favoritos', controller: 'products', action: 'favourites', locale: 'es'
+    assert_routing URI.escape('/ru/люди/кандидаты'), controller: 'people/products', action: 'favourites', locale: 'ru'
+    assert_routing URI.escape('/ru/избранное'), controller: 'products', action: 'favourites', locale: 'ru'
   end
 
   def test_unnamed_root_route_without_prefix


### PR DESCRIPTION
Todo:
- [x] Bring [GPA](https://codeclimate.com/github/enriclluelles/route_translator/compare/feature/namespaced-routes#ratings) back to 4.0
- [x] Improve `translate_string` method
- [ ] Other?
