### PR TITLE
Partially restore URI.escape behaviour to avoid breaking change

### DIFF
--- a/lib/route_translator/translator/path/segment.rb
+++ b/lib/route_translator/translator/path/segment.rb
@@ -35,7 +35,8 @@ module RouteTranslator
             sanitized_locale = RouteTranslator::LocaleSanitizer.sanitize(locale)
             translated_resource = translate_resource(str, sanitized_locale, scope)
 
-            CGI.escape translated_resource
+            # restore URI.escape behaviour to avoid breaking change
+            CGI.escape(translated_resource).gsub('%2F', '/')
           end
         end
 

--- a/test/dummy/app/controllers/dummy_controller.rb
+++ b/test/dummy/app/controllers/dummy_controller.rb
@@ -20,4 +20,8 @@ class DummyController < ActionController::Base
   def engine
     render plain: blorgh.posts_path
   end
+
+  def slash
+    render plain: request.env['PATH_INFO']
+  end
 end

--- a/test/dummy/config/locales/all.yml
+++ b/test/dummy/config/locales/all.yml
@@ -10,6 +10,7 @@ es:
     dummy: dummy
     show: mostrar
     suffix: sufijo
+    slash: foo/bar
 ru:
   routes:
     dummy: манекен

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   localized do
     get 'dummy',  to: 'dummy#dummy'
     get 'show',   to: 'dummy#show'
+    get 'slash',  to: 'dummy#slash'
 
     get 'optional(/:page)',            to: 'dummy#optional', as: :optional
     get 'prefixed_optional(/p-:page)', to: 'dummy#prefixed_optional', as: :prefixed_optional

--- a/test/integration/generated_path_test.rb
+++ b/test/integration/generated_path_test.rb
@@ -74,4 +74,10 @@ class GeneratedPathTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal '10', response.body
   end
+
+  def test_path_with_slash_in_translation
+    get '/es/foo/bar'
+    assert_response :success
+    assert_equal '/es/foo/bar', response.body
+  end
 end

--- a/test/locales/routes.yml
+++ b/test/locales/routes.yml
@@ -5,6 +5,7 @@ es:
     tr_param: tr_parametro
     favourites: favoritos
     blank: ""
+    slash: foo/bar
     controllers:
       people:
         products:

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -53,6 +53,16 @@ class TranslateRoutesTest < ActionController::TestCase
     assert_routing '/es/productos/product_slug', controller: 'products', action: 'show', locale: 'es', id: 'product_slug'
   end
 
+  def test_slash_in_translation
+    draw_routes do
+      localized do
+        get 'slash', to: 'products#index'
+      end
+    end
+
+    assert_routing '/es/foo/bar', controller: 'products', action: 'index', locale: 'es'
+  end
+
   def test_optional_segments
     draw_routes do
       localized do


### PR DESCRIPTION
Hi!

First: Thanks for maintaining this gem!

After updating to the lastest version i've noticed a breaking change regarding handling of slashes in translation files. Some investigation showed that the commit dc77562 changed the behaviour how the translated paths are escaped.

While avoiding `URI.escape` is desirable, such a big change in the way translated paths are handled should maybe happen in a major gem update?

I'm open to different solutions and i've started to avoid slashes in translation files, but maybe we should restore the old behaviour for now and change this in a bigger update?