### PR TITLE
 Restore URI.escape behaviour by using addressable gem

### DIFF
--- a/lib/route_translator/translator/path/segment.rb
+++ b/lib/route_translator/translator/path/segment.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'addressable/uri'
 
 module RouteTranslator
   module Translator
@@ -35,8 +36,9 @@ module RouteTranslator
             sanitized_locale = RouteTranslator::LocaleSanitizer.sanitize(locale)
             translated_resource = translate_resource(str, sanitized_locale, scope)
 
-            # restore URI.escape behaviour to avoid breaking change
-            CGI.escape(translated_resource).gsub('%2F', '/')
+            Addressable::URI.parse(translated_resource).normalize.to_s
+          rescue Addressable::URI::InvalidURIError
+            translated_resource
           end
         end
 

--- a/lib/route_translator/translator/path/segment.rb
+++ b/lib/route_translator/translator/path/segment.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'addressable/uri'
 
 module RouteTranslator

--- a/route_translator.gemspec
+++ b/route_translator.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'actionpack', '>= 5.0.0.1', '< 5.2'
   spec.add_runtime_dependency 'activesupport', '>= 5.0.0.1', '< 5.2'
 
+  spec.add_development_dependency 'addressable', '~> 2.4'
   spec.add_development_dependency 'appraisal', '~> 2.2'
   spec.add_development_dependency 'byebug', '~> 9.1'
   spec.add_development_dependency 'coveralls_reborn', '~> 0.10.0'

--- a/test/dummy/app/controllers/dummy_controller.rb
+++ b/test/dummy/app/controllers/dummy_controller.rb
@@ -24,4 +24,8 @@ class DummyController < ActionController::Base
   def slash
     render plain: request.env['PATH_INFO']
   end
+
+  def space
+    render plain: request.env['PATH_INFO']
+  end
 end

--- a/test/dummy/config/locales/all.yml
+++ b/test/dummy/config/locales/all.yml
@@ -11,6 +11,7 @@ es:
     show: mostrar
     suffix: sufijo
     slash: foo/bar
+    space: foo bar
 ru:
   routes:
     dummy: манекен

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     get 'dummy',  to: 'dummy#dummy'
     get 'show',   to: 'dummy#show'
     get 'slash',  to: 'dummy#slash'
+    get 'space',  to: 'dummy#space'
 
     get 'optional(/:page)',            to: 'dummy#optional', as: :optional
     get 'prefixed_optional(/p-:page)', to: 'dummy#prefixed_optional', as: :prefixed_optional

--- a/test/integration/generated_path_test.rb
+++ b/test/integration/generated_path_test.rb
@@ -80,4 +80,10 @@ class GeneratedPathTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal '/es/foo/bar', response.body
   end
+
+  def test_path_with_space_in_translation
+    get '/es/foo%20bar'
+    assert_response :success
+    assert_equal '/es/foo%20bar', response.body
+  end
 end

--- a/test/locales/routes.yml
+++ b/test/locales/routes.yml
@@ -6,6 +6,7 @@ es:
     favourites: favoritos
     blank: ""
     slash: foo/bar
+    space: foo bar
     controllers:
       people:
         products:

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -63,6 +63,16 @@ class TranslateRoutesTest < ActionController::TestCase
     assert_routing '/es/foo/bar', controller: 'products', action: 'index', locale: 'es'
   end
 
+  def test_space_in_translation
+    draw_routes do
+      localized do
+        get 'space', to: 'products#index'
+      end
+    end
+
+    assert_routing '/es/foo%20bar', controller: 'products', action: 'index', locale: 'es'
+  end
+
   def test_optional_segments
     draw_routes do
       localized do


### PR DESCRIPTION
### Issue:
https://github.com/enriclluelles/route_translator/issues/181