### PR TITLE
Fix overriding ActionController::Live with test_behaviour when not test mode.

### DIFF
--- a/lib/route_translator/extensions/action_controller.rb
+++ b/lib/route_translator/extensions/action_controller.rb
@@ -42,5 +42,5 @@ end
 
 ActiveSupport.on_load(:action_controller) do
   ActionController::Base.send :include, RouteTranslator::Controller
-  ActionController::TestCase.send :include, RouteTranslator::TestCase
+  ActionController::TestCase.send :include, RouteTranslator::TestCase if ENV['RAILS_ENV'] == 'test'
 end

--- a/lib/route_translator/translator/route_helpers.rb
+++ b/lib/route_translator/translator/route_helpers.rb
@@ -34,7 +34,7 @@ module RouteTranslator
             __send__(Translator.route_name_for(args, old_name, suffix, self), *args)
           end
 
-          add_helpers_to_test_cases(helper_container)
+          add_helpers_to_test_cases(helper_container) if ENV['RAILS_ENV'] == 'test'
         end
       end
     end

--- a/lib/route_translator/version.rb
+++ b/lib/route_translator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RouteTranslator
-  VERSION = '5.6.0'.freeze
+  VERSION = '5.6.1'.freeze
 end


### PR DESCRIPTION
Including [ActionController::TestCase::Behavior](https://github.com/rails/rails/blob/v5.1.5/actionpack/lib/action_controller/test_case.rb#L20) overrides `ActionController::Live#new_controller_thread` as discussed on https://github.com/rails/rails/issues/31200. This issue also affects any production mode as the include is not done just in test mode.

This pull request separates production code from test code by query the environment. I am not satisfied by this solution. In the future we should think about separating even more by  monkey patching in tests only. 