### PR TITLE
Add Rails > 6.0.0.rc1 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev / unreleased
 
+* [FEATURE] Add Rails > 6.0.0.rc1 compatibility
 * [ENHANCEMENT] Update development dependencies
 
 ## 6.0.0 / 2019-05-16

--- a/lib/route_translator/extensions/route_set.rb
+++ b/lib/route_translator/extensions/route_set.rb
@@ -25,18 +25,19 @@ module ActionDispatch
       private
 
       def translate_mapping(locale, route_set, translated_options, translated_path_ast, scope, controller, default_action, to, formatted, via, translated_options_constraints, anchor)
-        options = scope[:options] ? scope[:options].merge(translated_options) : translated_options
-
-        defaults          = (scope[:defaults] || {}).dup
-        scope_constraints = scope[:constraints] || {}
-
-        blocks = scope[:blocks] ? scope[:blocks].dup : []
+        scope_params = {
+          blocks:      scope[:blocks] || [],
+          constraints: scope[:constraints] || {},
+          defaults:    (scope[:defaults] || {}).dup,
+          module:      scope[:module],
+          options:     scope[:options] ? scope[:options].merge(translated_options) : translated_options
+        }
 
         if RouteTranslator.config.verify_host_path_consistency
-          blocks.push RouteTranslator::HostPathConsistencyLambdas.for_locale(locale)
+          scope_params[:blocks].push RouteTranslator::HostPathConsistencyLambdas.for_locale(locale)
         end
 
-        ::ActionDispatch::Routing::Mapper::Mapping.new(route_set, translated_path_ast, defaults, controller, default_action, scope[:module], to, formatted, scope_constraints, blocks, via, translated_options_constraints, anchor, options)
+        ::ActionDispatch::Routing::Mapper::Mapping.build scope_params, route_set, translated_path_ast, controller, default_action, to, via, formatted, translated_options_constraints, anchor, translated_options
       end
 
       def add_route_to_set(mapping, path_ast, name, anchor)


### PR DESCRIPTION
PR rails/rails#34656 has recently been merged to rails master and
backported to the rails 6-0-stable branch. It added an extra argument
to the Mapper::Mapping.new method which makes it incompatible with the
current version of route_translator 

This change is going to use `Mapper::Mapping.build` instead of
`Mapper::Mapping.new` because the former preserved its signature across
all Rails versions

Fix: #195

Ref: rails/rails@85855d63fc