### PR TITLE
Do not raise InvalidLocale errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## dev / unreleased
 
 * [FEATURE] Add Rails > 6.0.0.rc1 compatibility
+* [FEATURE] Do not raise InvalidLocale errors
 * [ENHANCEMENT] Update development dependencies
 
 ## 6.0.0 / 2019-05-16

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -68,4 +68,9 @@ module RouteTranslator
   def locale_param_key
     config.locale_param_key
   end
+
+  def locale_from_params(params)
+    locale = params[config.locale_param_key]&.to_sym
+    locale if I18n.available_locales.include?(locale)
+  end
 end

--- a/lib/route_translator/extensions/action_controller.rb
+++ b/lib/route_translator/extensions/action_controller.rb
@@ -14,7 +14,7 @@ module RouteTranslator
     private
 
     def set_locale_from_url
-      locale_from_url = params[RouteTranslator.locale_param_key] || RouteTranslator::Host.locale_from_host(request.host)
+      locale_from_url = RouteTranslator.locale_from_params(params) || RouteTranslator::Host.locale_from_host(request.host)
       if locale_from_url
         old_locale  = I18n.locale
         I18n.locale = locale_from_url

--- a/lib/route_translator/extensions/action_controller.rb
+++ b/lib/route_translator/extensions/action_controller.rb
@@ -14,15 +14,15 @@ module RouteTranslator
     private
 
     def set_locale_from_url
-      tmp_locale = params[RouteTranslator.locale_param_key] || RouteTranslator::Host.locale_from_host(request.host)
-      if tmp_locale
-        current_locale = I18n.locale
-        I18n.locale    = tmp_locale
+      locale_from_url = params[RouteTranslator.locale_param_key] || RouteTranslator::Host.locale_from_host(request.host)
+      if locale_from_url
+        old_locale  = I18n.locale
+        I18n.locale = locale_from_url
       end
 
       yield
     ensure
-      I18n.locale = current_locale if tmp_locale
+      I18n.locale = old_locale if locale_from_url
     end
   end
 

--- a/lib/route_translator/host.rb
+++ b/lib/route_translator/host.rb
@@ -26,7 +26,7 @@ module RouteTranslator
         result << locale.to_sym if host =~ regex_for(pattern)
       end
       locales &= I18n.available_locales
-      (locales.first || I18n.default_locale).to_sym
+      locales.first&.to_sym
     end
   end
 end

--- a/test/dummy/app/controllers/dummy_controller.rb
+++ b/test/dummy/app/controllers/dummy_controller.rb
@@ -28,4 +28,8 @@ class DummyController < ActionController::Base
   def space
     render plain: request.env['PATH_INFO']
   end
+
+  def unlocalized
+    render plain: I18n.locale
+  end
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     mount Blorgh::Engine, at: '/blorgh'
   end
 
+  get 'unlocalized', to: 'dummy#unlocalized'
   get 'partial_caching', to: 'dummy#partial_caching'
   get 'native', to: 'dummy#native'
   get 'engine_es', to: 'dummy#engine_es'

--- a/test/host_test.rb
+++ b/test/host_test.rb
@@ -66,8 +66,8 @@ class TestHostsFromLocale < Minitest::Test
     assert_equal :en, RouteTranslator::Host.locale_from_host('russia.com')
   end
 
-  def test_default_locale_if_no_matches
-    assert_equal I18n.default_locale, RouteTranslator::Host.locale_from_host('nomatches.co.uk')
+  def test_nil_if_no_matches
+    assert_nil RouteTranslator::Host.locale_from_host('nomatches.co.uk')
   end
 
   def test_readme_examples_work

--- a/test/integration/invalid_locales_test.rb
+++ b/test/integration/invalid_locales_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RoutingTest < ActionDispatch::IntegrationTest
+  include RouteTranslator::ConfigurationHelper
+
+  def test_do_not_raise_invalid_locale_error_for_invalid_locales
+    get '/unlocalized?locale=xx'
+    assert_response :success
+    assert_equal 'en', @response.body
+  end
+
+  def test_accepts_valid_locales
+    get '/unlocalized?locale=es'
+    assert_response :success
+    assert_equal 'es', @response.body
+  end
+end


### PR DESCRIPTION
When a user passes an invalid locale to an unlocalized route (such as
ActiveStorage routes or routes outside the `localized` block),
`route_translator` does not check if the locale is included in the
available locales list and a default Rails configuration will raise
an InvalidLocale error.

This behaviour could potentially open to DOS attacks (eg: flooding an
exception tracker)

This commit will prevent to set locales that are not included in
`I18n.available_locales`

Close: #196