### PR TITLE
Feature: Refactor Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,9 +298,9 @@ RouteTranslator.config.host_locales = { '*.com'    => :en, 'russia.*' => :ru } #
 If `host_locales` option is set, the following options will be forced (even if you set to true):
 
 ```ruby
+@config.force_locale                        = false
 @config.generate_unlocalized_routes         = false
 @config.generate_unnamed_unlocalized_routes = false
-@config.force_locale                        = false
 @config.hide_locale                         = false
 ```
 

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -13,36 +13,40 @@ module RouteTranslator
 
   TRANSLATABLE_SEGMENT = /^([-_a-zA-Z0-9]+)(\()?/.freeze
 
-  Configuration = Struct.new(:available_locales, :disable_fallback, :force_locale,
-                             :hide_locale, :host_locales, :generate_unlocalized_routes,
-                             :generate_unnamed_unlocalized_routes, :locale_param_key,
-                             :locale_segment_proc, :verify_host_path_consistency)
+  DEFAULT_CONFIGURATION = {
+    available_locales:                   [],
+    disable_fallback:                    false,
+    force_locale:                        false,
+    generate_unlocalized_routes:         false,
+    generate_unnamed_unlocalized_routes: false,
+    hide_locale:                         false,
+    host_locales:                        ActiveSupport::OrderedHash.new,
+    locale_param_key:                    :locale,
+    locale_segment_proc:                 false,
+    verify_host_path_consistency:        false
+  }.freeze
+
+  Configuration = Struct.new(*DEFAULT_CONFIGURATION.keys)
 
   class << self
     private
 
     def resolve_host_locale_config_conflicts
       @config.force_locale                        = false
-      @config.hide_locale                         = false
       @config.generate_unlocalized_routes         = false
       @config.generate_unnamed_unlocalized_routes = false
+      @config.hide_locale                         = false
     end
   end
 
   module_function
 
   def config(&block)
-    @config                                     ||= Configuration.new
-    @config.available_locales                   ||= []
-    @config.disable_fallback                    ||= false
-    @config.force_locale                        ||= false
-    @config.hide_locale                         ||= false
-    @config.host_locales                        ||= ActiveSupport::OrderedHash.new
-    @config.generate_unlocalized_routes         ||= false
-    @config.generate_unnamed_unlocalized_routes ||= false
-    @config.locale_param_key                    ||= :locale
-    @config.locale_segment_proc                 ||= false
-    @config.verify_host_path_consistency        ||= false
+    @config ||= Configuration.new
+
+    DEFAULT_CONFIGURATION.each do |option, value|
+      @config[option] ||= value
+    end
 
     yield @config if block
 

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -20,7 +20,7 @@ module RouteTranslator
     generate_unlocalized_routes:         false,
     generate_unnamed_unlocalized_routes: false,
     hide_locale:                         false,
-    host_locales:                        ActiveSupport::OrderedHash.new,
+    host_locales:                        {},
     locale_param_key:                    :locale,
     locale_segment_proc:                 false,
     verify_host_path_consistency:        false

--- a/test/helpers/helper_test.rb
+++ b/test/helpers/helper_test.rb
@@ -14,7 +14,6 @@ class TestHelperTest < ActionView::TestCase
 
   def setup
     setup_config
-    config_default_locale_settings 'en'
 
     @routes = ActionDispatch::Routing::RouteSet.new
 

--- a/test/integration/generated_path_test.rb
+++ b/test/integration/generated_path_test.rb
@@ -35,7 +35,6 @@ class GeneratedPathTest < ActionDispatch::IntegrationTest
   end
 
   def test_path_translated_while_generate_unlocalized_routes
-    config_default_locale_settings 'en'
     config_generate_unlocalized_routes true
 
     get '/es/mostrar'

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -6,8 +6,6 @@ class RoutingTest < ActionDispatch::IntegrationTest
   include RouteTranslator::ConfigurationHelper
 
   def test_set_locale_from_params
-    config_default_locale_settings 'en'
-
     get '/es/dummy'
     assert_equal 'es', @response.body
     assert_response :success

--- a/test/integration/thread_safety_test.rb
+++ b/test/integration/thread_safety_test.rb
@@ -14,8 +14,6 @@ class ThreadSafetyTest < ActionDispatch::IntegrationTest
   end
 
   def test_i18n_locale_thread_safe
-    config_default_locale_settings 'en'
-
     get '/es/dummy'
     assert_equal 'es', @response.body
 

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -125,7 +125,7 @@ class TranslateRoutesTest < ActionController::TestCase
   end
 
   def test_resources
-    config_default_locale_settings 'es'
+    I18n.default_locale = :es
 
     draw_routes do
       localized do
@@ -150,7 +150,7 @@ class TranslateRoutesTest < ActionController::TestCase
   end
 
   def test_resources_with_only
-    config_default_locale_settings 'es'
+    I18n.default_locale = :es
 
     draw_routes do
       localized do
@@ -165,7 +165,7 @@ class TranslateRoutesTest < ActionController::TestCase
   end
 
   def test_namespaced_controllers
-    config_default_locale_settings 'es'
+    I18n.default_locale = :es
 
     draw_routes do
       localized do
@@ -181,7 +181,7 @@ class TranslateRoutesTest < ActionController::TestCase
   end
 
   def test_unnamed_root_route_without_prefix
-    config_default_locale_settings 'es'
+    I18n.default_locale = :es
 
     draw_routes do
       localized do
@@ -216,7 +216,7 @@ class TranslateRoutesTest < ActionController::TestCase
   end
 
   def test_unnamed_translated_route_on_default_locale
-    config_default_locale_settings 'es'
+    I18n.default_locale = :es
 
     @routes.draw { get 'people', to: 'people#index' }
     draw_routes do
@@ -253,7 +253,7 @@ class TranslateRoutesTest < ActionController::TestCase
   end
 
   def test_named_empty_route_without_prefix
-    config_default_locale_settings 'es'
+    I18n.default_locale = :es
     draw_routes do
       localized do
         root to: 'people#index', as: 'people'
@@ -266,7 +266,7 @@ class TranslateRoutesTest < ActionController::TestCase
   end
 
   def test_named_root_route_without_prefix
-    config_default_locale_settings 'es'
+    I18n.default_locale = :es
 
     draw_routes do
       localized do
@@ -280,7 +280,7 @@ class TranslateRoutesTest < ActionController::TestCase
   end
 
   def test_named_untranslated_route_without_prefix
-    config_default_locale_settings 'es'
+    I18n.default_locale = :es
 
     draw_routes do
       localized do
@@ -295,7 +295,7 @@ class TranslateRoutesTest < ActionController::TestCase
   end
 
   def test_named_translated_route_on_default_locale_without_prefix
-    config_default_locale_settings 'es'
+    I18n.default_locale = :es
 
     draw_routes do
       localized do
@@ -418,7 +418,6 @@ class TranslateRoutesTest < ActionController::TestCase
   end
 
   def test_not_localizing_routes_outside_blocks
-    config_default_locale_settings 'en'
     draw_routes do
       localized do
         get 'people', to: 'people#index', as: 'people'
@@ -509,7 +508,7 @@ class TranslateRoutesTest < ActionController::TestCase
   end
 
   def test_path_helper_arguments
-    config_default_locale_settings 'es'
+    I18n.default_locale = :es
     I18n.with_locale :es do
       config_host_locales '*.es' => 'es', '*.com' => 'en'
 
@@ -529,7 +528,7 @@ class TranslateRoutesTest < ActionController::TestCase
   end
 
   def test_dont_add_locale_to_routes_if_local_param_present
-    config_default_locale_settings 'es'
+    I18n.default_locale = :es
     config_force_locale true
 
     draw_routes do
@@ -661,7 +660,7 @@ class ProductsControllerTest < ActionController::TestCase
 
     @routes = ActionDispatch::Routing::RouteSet.new
 
-    config_default_locale_settings 'es'
+    I18n.default_locale = :es
     config_host_locales es: 'es'
 
     draw_routes do

--- a/test/support/configuration_helper.rb
+++ b/test/support/configuration_helper.rb
@@ -2,52 +2,24 @@
 
 module RouteTranslator
   module ConfigurationHelper
-    BOOLEAN_OPTIONS = {
-      disable_fallback:                    false,
-      force_locale:                        false,
-      hide_locale:                         false,
-      generate_unlocalized_routes:         false,
-      generate_unnamed_unlocalized_routes: false
-    }.freeze
-
     def config_reset
-      config_available_locales            []
-      config_default_locale_settings      :en
-      config_host_locales                 {}
-      config_locale_segment_proc          false
-      config_verify_host_path_consistency false
+      config_default_locale_settings :en
 
-      BOOLEAN_OPTIONS.each do |option, default_value|
-        send(:"config_#{option}", default_value)
+      RouteTranslator::DEFAULT_CONFIGURATION.each do |option, value|
+        RouteTranslator.config[option] = value
       end
     end
 
     alias setup_config config_reset
     alias teardown_config config_reset
 
-    def config_available_locales(arr)
-      RouteTranslator.config.available_locales = arr
-    end
-
-    def config_default_locale_settings(locale)
+    def config_default_locale_settings(locale = :en)
       I18n.default_locale = locale
     end
 
-    def config_host_locales(hash = {})
-      RouteTranslator.config.host_locales = hash
-    end
-
-    def config_locale_segment_proc(a_proc)
-      RouteTranslator.config.locale_segment_proc = a_proc
-    end
-
-    def config_verify_host_path_consistency(value)
-      RouteTranslator.config.verify_host_path_consistency = value
-    end
-
-    BOOLEAN_OPTIONS.each_key do |option|
-      define_method :"config_#{option}" do |bool|
-        RouteTranslator.config.send(:"#{option}=", bool)
+    DEFAULT_CONFIGURATION.each do |option, default_value|
+      define_method :"config_#{option}" do |value = default_value|
+        RouteTranslator.config[option] = value
       end
     end
   end

--- a/test/support/configuration_helper.rb
+++ b/test/support/configuration_helper.rb
@@ -3,8 +3,6 @@
 module RouteTranslator
   module ConfigurationHelper
     def config_reset
-      config_default_locale_settings :en
-
       RouteTranslator::DEFAULT_CONFIGURATION.each do |option, value|
         RouteTranslator.config[option] = value
       end
@@ -12,10 +10,6 @@ module RouteTranslator
 
     alias setup_config config_reset
     alias teardown_config config_reset
-
-    def config_default_locale_settings(locale = :en)
-      I18n.default_locale = locale
-    end
 
     DEFAULT_CONFIGURATION.each do |option, default_value|
       define_method :"config_#{option}" do |value = default_value|

--- a/test/support/i18n_helper.rb
+++ b/test/support/i18n_helper.rb
@@ -3,21 +3,23 @@
 module RouteTranslator
   module I18nHelper
     def setup_i18n
-      @i18n_backend   = I18n.backend
-      @i18n_load_path = I18n.load_path
-      @i18n_locale    = I18n.locale
+      @i18n_backend        = I18n.backend
+      @i18n_default_locale = I18n.default_locale
+      @i18n_load_path      = I18n.load_path
+      @i18n_locale         = I18n.locale
 
-      I18n.backend    = I18n::Backend::Simple.new
-      I18n.load_path  = [File.expand_path('../locales/routes.yml', __dir__)]
-      I18n.locale     = I18n.default_locale
+      I18n.backend   = I18n::Backend::Simple.new
+      I18n.load_path = [File.expand_path('../locales/routes.yml', __dir__)]
+      I18n.locale    = I18n.default_locale
 
       I18n.reload!
     end
 
     def teardown_i18n
-      I18n.backend    = @i18n_backend
-      I18n.load_path  = @i18n_load_path
-      I18n.locale     = @i18n_locale
+      I18n.backend        = @i18n_backend
+      I18n.default_locale = @i18n_default_locale
+      I18n.load_path      = @i18n_load_path
+      I18n.locale         = @i18n_locale
 
       I18n.reload!
     end

--- a/test/test_case_helpers_test.rb
+++ b/test/test_case_helpers_test.rb
@@ -11,8 +11,6 @@ class TestCaseHelpersTest < MiniTest::Test
 
     @routes = ActionDispatch::Routing::RouteSet.new
 
-    config_default_locale_settings 'en'
-
     draw_routes do
       localized do
         resources :people
@@ -65,8 +63,6 @@ class TestControllerTest < ActionController::TestCase
     setup_config
 
     @routes = ActionDispatch::Routing::RouteSet.new
-
-    config_default_locale_settings 'en'
 
     draw_routes do
       get :test, to: 'test#test'


### PR DESCRIPTION
Keeps the default settings in a single place, instead of having it in
both `route_translator.rb` and `configuration_helper.rb`

There is no `default_locale` setting in Route Translator.
The previous method was just an alias for `I18n.default_locale`.

This change will remove this ambiguity and change i18n helpers
to properly reset default locale between tests