### PR TITLE
FIX: missing dup on blocks

### DIFF
--- a/lib/route_translator/extensions/route_set.rb
+++ b/lib/route_translator/extensions/route_set.rb
@@ -26,9 +26,9 @@ module ActionDispatch
 
       def translate_mapping(locale, route_set, translated_options, translated_path_ast, scope, controller, default_action, to, formatted, via, translated_options_constraints, anchor)
         scope_params = {
-          blocks:      scope[:blocks] || [],
+          blocks:      (scope[:blocks] || []).dup,
           constraints: scope[:constraints] || {},
-          defaults:    (scope[:defaults] || {}).dup,
+          defaults:    scope[:defaults] || {},
           module:      scope[:module],
           options:     scope[:options] ? scope[:options].merge(translated_options) : translated_options
         }

--- a/test/dummy/app/controllers/account/foo_controller.rb
+++ b/test/dummy/app/controllers/account/foo_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Account
+  class FooController < ActionController::Base
+    around_action :set_locale_from_url
+
+    def account_root
+      render plain: "works: #{I18n.locale}"
+    end
+  end
+end

--- a/test/dummy/config/locales/all.yml
+++ b/test/dummy/config/locales/all.yml
@@ -6,6 +6,7 @@ en:
     dummy: dummy
     dummy_without_around_action: dummy_without_around_action
     show: show
+    account: account
 es:
   routes:
     dummy: dummy
@@ -14,12 +15,15 @@ es:
     suffix: sufijo
     slash: foo/bar
     space: foo bar
+    account: cuenta
 ru:
   routes:
     dummy: манекен
     show: показывать
+    account: профиль
 
 de-AT:
   routes:
     dummy: Attrappe
     show: anzeigen
+    account: konto

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -16,6 +16,10 @@ Rails.application.routes.draw do
 
     get ':id-suffix', to: 'dummy#suffix'
 
+    namespace :account do
+      root to: 'foo#account_root'
+    end
+
     mount Blorgh::Engine, at: '/blorgh'
   end
 

--- a/test/integration/namespace_test.rb
+++ b/test/integration/namespace_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class NamespaceTest < ActionDispatch::IntegrationTest
+  include RouteTranslator::ConfigurationHelper
+
+  def setup
+    config_verify_host_path_consistency true
+    config_host_locales '*.es' => 'es', 'ru.*.com' => 'ru'
+    Dummy::Application.reload_routes!
+  end
+
+  def teardown
+    config_verify_host_path_consistency false
+    config_host_locales
+    Dummy::Application.reload_routes!
+  end
+
+  def test_namespacing
+    host! 'www.testapp.es'
+
+    get '/cuenta'
+
+    assert_response :success
+    assert_equal 'works: es', response.body
+  end
+end


### PR DESCRIPTION
The dup of the `blocks` argument was removed on the last refactor of the route_set, but it was necessary. On the other hand, `defaults` doesn't need a dup since this is already done inside `::ActionDispatch::Routing::Mapper::Mapping.build`.

The new test showcases the bug (404 response) with the previous code.