### PR TITLE
Fixed lazy load action controller

### DIFF
--- a/lib/route_translator/extensions/action_controller.rb
+++ b/lib/route_translator/extensions/action_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'action_controller'
 require 'active_support/concern'
 
 module RouteTranslator
@@ -21,22 +20,12 @@ module RouteTranslator
       I18n.locale = old_locale if locale_from_url
     end
   end
-
-  module TestCase
-    extend ActiveSupport::Concern
-    include ActionController::UrlFor
-
-    included do
-      delegate :env, :request, to: :@controller
-    end
-
-    def _routes
-      @routes
-    end
-  end
 end
 
 ActiveSupport.on_load(:action_controller) do
-  ActionController::Base.include RouteTranslator::Controller
-  ActionController::TestCase.include RouteTranslator::TestCase if ENV['RAILS_ENV'] == 'test'
+  include RouteTranslator::Controller
+  if ENV['RAILS_ENV'] == 'test'
+    require 'route_translator/extensions/test_case'
+    ActionController::TestCase.include RouteTranslator::TestCase
+  end
 end

--- a/lib/route_translator/extensions/test_case.rb
+++ b/lib/route_translator/extensions/test_case.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'action_controller'
+
+module RouteTranslator
+  module TestCase
+    extend ActiveSupport::Concern
+    include ActionController::UrlFor
+
+    included do
+      delegate :env, :request, to: :@controller
+    end
+
+    def _routes
+      @routes
+    end
+  end
+end


### PR DESCRIPTION
I found that the `ActiveSupport.on_load(:action_controller)` wasn't working as intented because `action_controller` was require on top.

I figured that requiring `test_case` only when needed would fix that small issue