### PR TITLE
URI.parser is deprecated and will be removed in Rails 6.2

### DIFF
--- a/lib/route_translator/extensions/mapper.rb
+++ b/lib/route_translator/extensions/mapper.rb
@@ -34,7 +34,7 @@ module ActionDispatch
                name_for_action(options.delete(:as), action)
              end
 
-        path = Mapping.normalize_path URI.parser.escape(path), formatted
+        path = Mapping.normalize_path URI::DEFAULT_PARSER.escape(path), formatted
         ast = Journey::Parser.parse path
 
         mapping = Mapping.build(@scope, @set, ast, controller, default_action, to, via, formatted, options_constraints, anchor, options)


### PR DESCRIPTION
I get a bunch of these when updating to Rails 6.1.0.rc1 (using route_translator 8.2.0, following the merge of #210):
```
DEPRECATION WARNING: URI.parser is deprecated and will be removed in Rails 6.2. Use `URI::DEFAULT_PARSER` instead.  (called from block (3 levels) in <top (required)> at .../config/routes.rb:77)
```

The stack trace points to various routes defined within the `localized do ... end` blocks present in my routing file, but nothing more specific. However I see a single instance of `URI.parser` in this gem's source code, so I guess this is it.