### PR TITLE
Allow to hide_locale when using host_locales config

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,6 @@ If `host_locales` option is set, the following options will be forced (even if y
 @config.force_locale                        = false
 @config.generate_unlocalized_routes         = false
 @config.generate_unnamed_unlocalized_routes = false
-@config.hide_locale                         = false
 ```
 
 This is to avoid odd behaviour brought about by route conflicts and because `host_locales` forces and hides the host-locale dynamically.

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -36,7 +36,6 @@ module RouteTranslator
       @config.force_locale                        = false
       @config.generate_unlocalized_routes         = false
       @config.generate_unnamed_unlocalized_routes = false
-      @config.hide_locale                         = false
     end
   end
 

--- a/lib/route_translator/host.rb
+++ b/lib/route_translator/host.rb
@@ -16,6 +16,8 @@ module RouteTranslator
     end
 
     def native_locales
+      return [] if RouteTranslator.config.hide_locale
+
       config.host_locales.values.map { |locale| :"native_#{locale}" }
     end
 

--- a/test/integration/host_locales_with_hide_locale_test.rb
+++ b/test/integration/host_locales_with_hide_locale_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class HostLocalesWithHideLocaleTest < ActionDispatch::IntegrationTest
+  include RouteTranslator::ConfigurationHelper
+
+  def setup
+    config_verify_host_path_consistency true
+    config_hide_locale true
+    config_host_locales '*.es' => 'es', '*.co.uk' => 'en'
+    Rails.application.reload_routes!
+  end
+
+  def teardown
+    teardown_config
+    Rails.application.reload_routes!
+  end
+
+  def test_explicit_path
+    # -- testapp.es --
+    host! 'testapp.es'
+
+    get '/'
+    assert_equal 'es', @response.body
+    assert_response :success
+
+    get '/mostrar'
+    assert_response :success
+
+    get '/es/mostrar'
+    assert_response :not_found
+
+    get '/show'
+    assert_response :not_found
+
+    get '/en/show'
+    assert_response :not_found
+
+    # -- testapp.co.uk --
+    host! 'testapp.co.uk'
+
+    get '/'
+    assert_equal 'en', @response.body
+    assert_response :success
+
+    get '/show'
+    assert_response :success
+
+    get '/en/show'
+    assert_response :not_found
+
+    get '/mostrar'
+    assert_response :not_found
+
+    get '/es/mostrar'
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
This is what I want to accomplish in this Pull Request:


<table>
<tbody>
<tr>
<td>HOST</td>
<td>PATH</td>
<td>Should be accessible?</td>
</tr>
<tr>
<td rowspan=5>testapp.es</td>
<td>/</td>
<td>:heavy_check_mark:</td>
</tr>
<tr>
<td>/mostrar</td>
<td>:heavy_check_mark:</td>
</tr>
<tr>
<td>/es/mostrar</td>
<td>:x:</td>
</tr>
<tr>
<td>/show</td>
<td>:x:</td>
</tr>
<tr>
<td>/en/show</td>
<td>:x:</td>
</tr>
<tr>
<td rowspan=5>testapp.co.uk</td>
<td>/</td>
<td>:heavy_check_mark:</td>
</tr>
<tr>
<td>/show</td>
<td>:heavy_check_mark:</td>
</tr>
<tr>
<td>/en/show</td>
<td>:x:</td>
</tr>
<tr>
<td>/mostrar</td>
<td>:x:</td>
</tr>
<tr>
<td>/es/mostrar</td>
<td>:x:</td>
</tr>
</tbody>
</table>

---

If you run my spec in `master` branch: 

- [`test/integration/host_locales_with_hide_locale_test.rb`](https://github.com/enriclluelles/route_translator/pull/239/files#diff-9d7846739b2bd5c72907520bccd409166f9e533b34c81cd1fa0d30ed2e568bee)

You will see that fails.