### PR TITLE
Add net-smtp gem explicitly

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -14,12 +14,27 @@ end
 
 appraise 'rails-6.0' do
   gem 'rails', '~> 6.0.0'
+
+  # net-smtp has been removed from default gems in Ruby 3.1, but it is used
+  # by the `mail` gem.
+  # Remove when https://github.com/mikel/mail/pull/1439 is fixed
+  gem 'net-smtp', require: false
 end
 
 appraise 'rails-6.1' do
-  gem 'rails', '~> 6.1.0.rc1'
+  gem 'rails', '~> 6.1.0'
+
+  # net-smtp has been removed from default gems in Ruby 3.1, but it is used
+  # by the `mail` gem.
+  # Remove when https://github.com/mikel/mail/pull/1439 is fixed
+  gem 'net-smtp', require: false
 end
 
 appraise 'rails-edge' do
   gem 'rails', git: 'https://github.com/rails/rails.git', branch: 'main'
+
+  # net-smtp has been removed from default gems in Ruby 3.1, but it is used
+  # by the `mail` gem.
+  # Remove when https://github.com/mikel/mail/pull/1439 is fixed
+  gem 'net-smtp', require: false
 end

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -8,5 +8,6 @@ gem "rubocop-performance", "~> 1.10.2"
 gem "rubocop-rails", "~> 2.9"
 gem "rubocop-rake", "~> 0.5.1"
 gem "rails", "~> 6.0.0"
+gem "net-smtp", require: false
 
 gemspec path: "../"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -7,6 +7,7 @@ gem "rubocop-minitest", "~> 0.11.1"
 gem "rubocop-performance", "~> 1.10.2"
 gem "rubocop-rails", "~> 2.9"
 gem "rubocop-rake", "~> 0.5.1"
-gem "rails", "~> 6.1.0.rc1"
+gem "rails", "~> 6.1.0"
+gem "net-smtp", require: false
 
 gemspec path: "../"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -8,5 +8,6 @@ gem "rubocop-performance", "~> 1.10.2"
 gem "rubocop-rails", "~> 2.9"
 gem "rubocop-rake", "~> 0.5.1"
 gem "rails", git: "https://github.com/rails/rails.git", branch: "main"
+gem "net-smtp", require: false
 
 gemspec path: "../"


### PR DESCRIPTION
net-smtp has been removed from default gems in Ruby 3.1, but it is used
by the `mail` gem.

Remove when mikel/mail#1439 is fixed