### PR TITLE
Fix disable fallback behavior

### DIFF
--- a/lib/route_translator/translator/path/segment.rb
+++ b/lib/route_translator/translator/path/segment.rb
@@ -9,7 +9,7 @@ module RouteTranslator
 
           def fallback_options(str, locale)
             if RouteTranslator.config.disable_fallback && locale.to_s != I18n.default_locale.to_s
-              { scope: :routes, fallback: true }
+              { scope: :routes, fallback: false }
             else
               { scope: :routes, default: str }
             end
@@ -25,7 +25,7 @@ module RouteTranslator
             opts    = { locale: locale, scope: scope }
 
             if I18n.t(str, **opts.merge(exception_handler: handler)).is_a?(I18n::MissingTranslation)
-              I18n.t str, **opts.merge(fallback_options(str, locale))
+              I18n.t! str, **opts.merge(fallback_options(str, locale))
             else
               I18n.t str, **opts
             end

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -684,6 +684,18 @@ class TranslateRoutesTest < ActionController::TestCase
 
     assert_unrecognized_route '/ru/tr_param', controller: 'people', action: 'index', locale: 'ru'
   end
+
+  def test_disable_fallback_does_not_draw_untranslated_routes
+    config_disable_fallback(true)
+
+    draw_routes do
+      localized do
+        resources :products
+      end
+    end
+
+    assert_not_respond_to @routes.url_helpers, :products_ru_path
+  end
 end
 
 class ProductsControllerTest < ActionController::TestCase


### PR DESCRIPTION
1. Do not enable fallback if disable_fallback option is enabled
2. Raise if the translation is not found, so that `translate_path` may
  rescue from it

Close #241

TODO:
- [x] failing test case