### PR TITLE
Add explicit permissions to workflows

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   rubocop:
     name: Rubocop

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -72,6 +72,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
+        rubygems: latest
     - name: Run tests
       run: bundle exec rake test
     - name: Coveralls Parallel

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Tests


### PR DESCRIPTION
Workflows run with extended set of permissions by default. By specifying any permission explicitly, all others are set to none.

Ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions