### PR TITLE
Add support for i18n lookup with the controller path instead of nested keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ end
 | `host_locales` | Sets `I18n.locale` based on `request.host`. Useful for apps accepting requests from more than one domain. See below for more details | `{}` |
 | `locale_param_key` | The param key used to set the locale to the newly generated routes | `:locale` |
 | `locale_segment_proc` | The locale segment of the url will by default be `locale.to_s.downcase`. You can supply your own mechanism via a Proc that takes `locale` as an argument, e.g. `->(locale) { locale.to_s.upcase }` | `false` |
+| `i18n_use_controller_path` | Use the exact controller path `account/foo` for looking up translations instead of nested keys `account.foo` | `false` |
 
 
 ### Host-based Locale

--- a/README.md
+++ b/README.md
@@ -280,8 +280,13 @@ end
 | `host_locales` | Sets `I18n.locale` based on `request.host`. Useful for apps accepting requests from more than one domain. See below for more details | `{}` |
 | `locale_param_key` | The param key used to set the locale to the newly generated routes | `:locale` |
 | `locale_segment_proc` | The locale segment of the url will by default be `locale.to_s.downcase`. You can supply your own mechanism via a Proc that takes `locale` as an argument, e.g. `->(locale) { locale.to_s.upcase }` | `false` |
-| `i18n_use_controller_path` | Use the exact controller path `account/foo` for looking up translations instead of nested keys `account.foo` | `false` |
+| `i18n_use_slash_separator` | Use the exact controller path `account/foo` for looking up translations instead of nested keys `account.foo` | `false` |
 
+#### Deprecated options
+
+- `i18n_use_slash_separator` is deprecated and will be forced to `true` in the next major release of Route Translator. This only
+  affects application with nested routes. Please set this option to `true` to remove the deprecation message and ensure
+  to convert nested routes like `people.products` to the new `people/products`.
 
 ### Host-based Locale
 

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -20,7 +20,8 @@ module RouteTranslator
     hide_locale:                         false,
     host_locales:                        {},
     locale_param_key:                    :locale,
-    locale_segment_proc:                 false
+    locale_segment_proc:                 false,
+    i18n_use_controller_path:            false
   }.freeze
 
   Configuration = Struct.new(*DEFAULT_CONFIGURATION.keys)

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -21,7 +21,7 @@ module RouteTranslator
     host_locales:                        {},
     locale_param_key:                    :locale,
     locale_segment_proc:                 false,
-    i18n_use_controller_path:            false
+    i18n_use_slash_separator:            false
   }.freeze
 
   Configuration = Struct.new(*DEFAULT_CONFIGURATION.keys)
@@ -34,6 +34,18 @@ module RouteTranslator
       @config.generate_unlocalized_routes         = false
       @config.generate_unnamed_unlocalized_routes = false
       @config.hide_locale                         = true
+    end
+
+    def check_deprecations
+      return if @config.i18n_use_slash_separator
+
+      ActiveSupport::Deprecation.warn <<~MSG
+        `i18n_use_slash_separator` set to `false` is deprecated and will be
+        removed in the next major release of Route Translator to match
+        Rails' ActiveRecord nested model syntax.
+
+        More information at https://github.com/enriclluelles/route_translator/pull/285
+      MSG
     end
   end
 
@@ -49,6 +61,7 @@ module RouteTranslator
     yield @config if block_given?
 
     resolve_host_locale_config_conflicts if @config.host_locales.present?
+    check_deprecations
 
     @config
   end

--- a/lib/route_translator/route.rb
+++ b/lib/route_translator/route.rb
@@ -16,7 +16,11 @@ module RouteTranslator
     def scope
       @scope ||=
         if mapping.defaults[:controller]
-          %i[routes controllers].concat mapping.defaults[:controller].split('/').map(&:to_sym)
+          if RouteTranslator.config.i18n_use_controller_path
+            %i[routes controllers].push mapping.defaults[:controller]
+          else
+            %i[routes controllers].concat mapping.defaults[:controller].split('/').map(&:to_sym)
+          end
         else
           %i[routes controllers]
         end

--- a/lib/route_translator/route.rb
+++ b/lib/route_translator/route.rb
@@ -16,7 +16,7 @@ module RouteTranslator
     def scope
       @scope ||=
         if mapping.defaults[:controller]
-          if RouteTranslator.config.i18n_use_controller_path
+          if RouteTranslator.config.i18n_use_slash_separator
             %i[routes controllers].push mapping.defaults[:controller]
           else
             %i[routes controllers].concat mapping.defaults[:controller].split('/').map(&:to_sym)

--- a/test/integration/i18n_slash_separator_test.rb
+++ b/test/integration/i18n_slash_separator_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class I18nSlashSeparatorTest < ActionDispatch::IntegrationTest
+  include RouteTranslator::ConfigurationHelper
+
+  def teardown
+    teardown_config
+  end
+
+  def test_deprecation_when_default
+    assert_deprecated('i18n_use_slash_separator') do
+      RouteTranslator.config
+    end
+  end
+
+  def test_deprecation_when_false
+    config_i18n_use_slash_separator false
+
+    assert_deprecated('i18n_use_slash_separator') do
+      RouteTranslator.config
+    end
+  end
+
+  def test_no_deprecation_when_true
+    config_i18n_use_slash_separator true
+
+    assert_not_deprecated do
+      RouteTranslator.config
+    end
+  end
+end

--- a/test/locales/routes.yml
+++ b/test/locales/routes.yml
@@ -12,7 +12,9 @@ es:
         products:
           products: productos_favoritos
           favourites: fans
-
+      people/products:
+        products: productos_new_favoritos
+        favourites: fans
 ru:
   routes:
     people: люди

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -158,6 +158,25 @@ class TranslateRoutesTest < ActionController::TestCase
     assert_routing '/gente/productos_favoritos', controller: 'people/products', action: 'index', locale: 'es'
   end
 
+  def test_controller_namespaced_resources
+    config_i18n_use_controller_path(true)
+    I18n.default_locale = :es
+
+    draw_routes do
+      localized do
+        resources :products
+
+        namespace :people do
+          resources :products
+        end
+      end
+    end
+
+    assert_routing '/productos', controller: 'products', action: 'index', locale: 'es'
+    assert_routing '/gente/productos_new_favoritos', controller: 'people/products', action: 'index', locale: 'es'
+    assert_unrecognized_route '/gente/productos_favoritos', controller: 'people/products', action: 'index', locale: 'es'
+  end
+
   def test_utf8_characters
     draw_routes do
       localized do

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -159,7 +159,7 @@ class TranslateRoutesTest < ActionController::TestCase
   end
 
   def test_controller_namespaced_resources
-    config_i18n_use_controller_path(true)
+    config_i18n_use_slash_separator(true)
     I18n.default_locale = :es
 
     draw_routes do


### PR DESCRIPTION
Add option for standard nested separator

This commit adds a new configuration option called `i18n_use_slash_separator`
to the Route Translator gem. This option controls whether or not to use the `/`
separator for nested route names in the gem's translation files.

The approach used in Route Translator was to remove the slash and prefer
a nested key. However, this commit changes the default separator to a slash
(`/`) character to match Rails' nested route syntax.

The old approach of using a nested key instead of a separator would have
prevented the following scenario:

```rb
Rails.application.routes.draw do
  localized do
    resources :appointments, only: :index do
      post :reservations, on: :member
    end
    namespace :appointments do
      resources :reservations, only: :index
    end
  end
end
```

because of the necessary double use of `reservations` under `appointments`.

Here's an example of how the new separator works in a translation file:

```yml
routes:
  controllers:
    people:
      products:
        favourites: fans

routes:
  controllers:
    people/products:
      favourites: fans
```

By default, the `i18n_use_slash_separator` option is set to false to preserve
backward compatibility with existing translation files.

However, if this option is set to `true`, Route Translator will use the slash
separator instead.

In the next major release of Route Translator, the `i18n_use_slash_separator`
option will be removed and the behavior will be forced to use the slash
separator.

Therefore, we recommend that users update their translation files to use the
slash separator and set the `i18n_use_slash_separator` option to `true` to
ensure compatibility with future versions of the gem.

## Upgrade guide

### No nested controllers
You are good to go. Just set `i18n_use_slash_separator` to true

### Nested controllers
Let's say that you have `People::Products` controller

Change `people.products` to `people/products`

