### PR TITLE
Allow generation of raw named routes with single locale configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ end
 | `host_locales` | Sets `I18n.locale` based on `request.host`. Useful for apps accepting requests from more than one domain. See below for more details | `{}` |
 | `locale_param_key` | The param key used to set the locale to the newly generated routes | `:locale` |
 | `locale_segment_proc` | The locale segment of the url will by default be `locale.to_s.downcase`. You can supply your own mechanism via a Proc that takes `locale` as an argument, e.g. `->(locale) { locale.to_s.upcase }` | `false` |
+| `generate_raw_named_localized_route`| Create named routes without the locale added to the name. **Note:** Only works with one available locale |
 
 
 ### Host-based Locale

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -20,7 +20,8 @@ module RouteTranslator
     hide_locale:                         false,
     host_locales:                        {},
     locale_param_key:                    :locale,
-    locale_segment_proc:                 false
+    locale_segment_proc:                 false,
+    generate_raw_named_localized_route:  false
   }.freeze
 
   Configuration = Struct.new(*DEFAULT_CONFIGURATION.keys)
@@ -33,6 +34,7 @@ module RouteTranslator
       @config.generate_unlocalized_routes         = false
       @config.generate_unnamed_unlocalized_routes = false
       @config.hide_locale                         = true
+      @config.generate_raw_named_localized_route  = false
     end
   end
 
@@ -75,5 +77,11 @@ module RouteTranslator
   def locale_from_params(params)
     locale = params[config.locale_param_key]&.to_sym
     locale if I18n.available_locales.include?(locale)
+  end
+
+  def generate_raw_named_localized_route
+    return if config.available_locales.many?
+
+    config.generate_raw_named_localized_route
   end
 end

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -69,7 +69,11 @@ module RouteTranslator
         translated_path = translate_path(route.path, locale, route.scope)
         next unless translated_path
 
-        translated_name                = translate_name(route.name, locale, route.route_set.named_routes.names)
+        translated_name                = if RouteTranslator.generate_raw_named_localized_route
+                                           route.name
+                                         else
+                                           translate_name(route.name, locale, route.route_set.named_routes.names)
+                                         end
         translated_options_constraints = translate_options_constraints(route.options_constraints, locale)
         translated_options             = translate_options(route.options, locale)
 

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -715,6 +715,34 @@ class TranslateRoutesTest < ActionController::TestCase
 
     assert_not_respond_to @routes.url_helpers, :products_ru_path
   end
+
+  def test_generate_raw_named_localized_route_does_draw_raw_localized_routes
+    config_available_locales([:en])
+    config_generate_raw_named_localized_route(true)
+
+    draw_routes do
+      localized do
+        resources :products
+      end
+    end
+
+    assert_not_respond_to @routes.url_helpers, :products_en_path
+    assert_respond_to @routes.url_helpers, :products_path
+  end
+
+  def test_generate_raw_named_localized_route_does_not_draw_raw_localized_routes_for_many_available_locales
+    config_available_locales([:en, :es])
+    config_generate_raw_named_localized_route(true)
+
+    draw_routes do
+      localized do
+        resources :products
+      end
+    end
+
+    assert_respond_to @routes.url_helpers, :products_en_path
+    assert_respond_to @routes.url_helpers, :products_es_path
+  end
 end
 
 class ProductsControllerTest < ActionController::TestCase


### PR DESCRIPTION
If there is only one locale like `es` it's now possible to generate routes like `products_path` instead of `products_es_path`.

It is not needed in a single locale application to use the localized route name.