### PR TITLE
Remove unneeded railtie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 14.0.1 / 2023-09-03
+
+* [BUGFIX] Fix eager load on booting ([#296](https://github.com/enriclluelles/route_translator/issues/296))
+
 ## 14.0.0 / 2023-09-02
 
 * [FEATURE] BREAKING CHANGE: Force standard nested separator (Upgrade guide at [#285](https://github.com/enriclluelles/route_translator/pull/285))

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -85,5 +85,3 @@ module RouteTranslator
     @deprecator ||= ActiveSupport::Deprecation.new(RouteTranslator::VERSION, 'RouteTranslator')
   end
 end
-
-require 'route_translator/railtie' if defined?(Rails)

--- a/lib/route_translator/railtie.rb
+++ b/lib/route_translator/railtie.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails/railtie'
-
-module RouteTranslator
-  class Railtie < Rails::Railtie
-    config.eager_load_namespaces << RouteTranslator
-  end
-end

--- a/lib/route_translator/version.rb
+++ b/lib/route_translator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RouteTranslator
-  VERSION = '14.0.0'
+  VERSION = '14.0.1'
 end


### PR DESCRIPTION
While adding the new initializer generator, an unneeded railtie was included by mistake

This commit removes the railtie

Fix #296