### PR TITLE
Memory leak in development mode

### DIFF
--- a/lib/route_translator/translator/route_helpers.rb
+++ b/lib/route_translator/translator/route_helpers.rb
@@ -27,6 +27,8 @@ module RouteTranslator
             __send__(Translator.route_name_for(args, old_name, suffix, self), *args)
           end
 
+          next unless ENV.fetch('RAILS_ENV', nil) == 'test'
+
           TEST_CASE_HOOKS.each do |test_case_hook|
             ActiveSupport.on_load(test_case_hook) do
               include helper_container


### PR DESCRIPTION
I noticed some weird memory usage in development and also request becoming slower every time I changed a file in my rails project.

After some digging I found this gem to be the issue. 

In this PR https://github.com/enriclluelles/route_translator/pull/284 this code was introduced. For some reason the check `if ENV.fetch('RAILS_ENV', nil) == 'test'` was removed. This made by development env very slow and it consumed a lot of memory.

We can just add this check back right?

example in rails console:

With current version:
```
 25.times { puts Benchmark.realtime { Rails.application.routes.clear!; Rails.application.routes_reloader.execute } }
1.07533899997361
1.1278870000387542
1.1042030000244267
1.332025000010617
1.351589999976568
1.416763000015635
1.560079999966547
1.6818230000208132
1.5159729999722913
1.9790309999953024
1.6546179999713786
1.8570000000181608
2.252521999995224
2.0277480000513606
2.1883889999589883
2.4619860000093468
2.448113000020385
2.481713999994099
2.539403000031598
2.735276999999769
2.895638999994844
2.901374999957625
2.8260779999545775
2.6724389999872074
3.584111000003759
```

Memory consumption about 1.2GB(!)

With this branch
```
25.times { puts Benchmark.realtime { Rails.application.routes.clear!; Rails.application.routes_reloader.execute } }
0.8356710000080056
0.6327389999642037
0.887994000047911
0.5161800000350922
0.5877099999925122
0.6168830000096932
0.5804869999992661
0.9465409999829717
0.6707010000245646
0.5576400000136346
0.569958999985829
0.6176609999965876
0.5508129999507219
0.562720000045374
0.6327919999603182
0.5536239999928512
0.5805980000295676
0.6246429999591783
0.5516260000295006
0.5636689999955706
0.6193329999805428
0.5529499999829568
0.5639959999825805
0.6199469999992289
0.5523309999844059
```

Memory consumption about 450MB