### PR TITLE
Allow Rails 8.0

### DIFF
--- a/route_translator.gemspec
+++ b/route_translator.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7'
 
-  spec.add_runtime_dependency 'actionpack', '>= 6.1', '< 7.2'
-  spec.add_runtime_dependency 'activesupport', '>= 6.1', '< 7.2'
+  spec.add_runtime_dependency 'actionpack', '>= 6.1', '< 8.0'
+  spec.add_runtime_dependency 'activesupport', '>= 6.1', '< 8.0'
 end


### PR DESCRIPTION
We're unable to test our project with edge Rails at the moment as route_translator doesn't officially support anything newer than 7.1 and the next version of Rails will be 8.0.

Ran the existing test suite against edge and they all seem to pass.