### PR TITLE
Fix "Test is missing assertions" warnings

### DIFF
--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -620,15 +620,7 @@ class TranslateRoutesTest < ActionController::TestCase
   end
 
   def test_action_controller_gets_locale_setter
-    ActionController::Base.instance_methods.include?('set_locale_from_url')
-  end
-
-  def test_action_controller_gets_locale_suffix_helper
-    ActionController::Base.instance_methods.include?('locale_suffix')
-  end
-
-  def test_action_view_gets_locale_suffix_helper
-    ActionView::Base.instance_methods.include?('locale_suffix')
+    assert_includes ActionController::Base.private_instance_methods, :set_locale_from_url
   end
 
   # See https://github.com/enriclluelles/route_translator/issues/69


### PR DESCRIPTION
Rails Edge produced some warnings:

- Test is missing assertions: `test_action_controller_gets_locale_setter`
- Test is missing assertions: `test_action_controller_gets_locale_suffix_helper`
- Test is missing assertions: `test_action_view_gets_locale_suffix_helper`

Those tests never worked because the assertion was missing (they were returning false) and broke at a certain point in time