### PR TITLE
Prefer `require_relative` for internal requires

### DIFF
--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -2,10 +2,10 @@
 
 require 'active_support'
 
-require 'route_translator/extensions'
-require 'route_translator/translator'
-require 'route_translator/host'
-require 'route_translator/version'
+require_relative 'route_translator/extensions'
+require_relative 'route_translator/translator'
+require_relative 'route_translator/host'
+require_relative 'route_translator/version'
 
 module RouteTranslator
   extend RouteTranslator::Host

--- a/lib/route_translator/extensions.rb
+++ b/lib/route_translator/extensions.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-require 'route_translator/extensions/mapper'
-require 'route_translator/extensions/route_set'
-require 'route_translator/extensions/action_controller'
+require_relative 'extensions/mapper'
+require_relative 'extensions/route_set'
+require_relative 'extensions/action_controller'

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'route_translator/translator/route_helpers'
-require 'route_translator/translator/path'
-require 'route_translator/route'
+require_relative 'translator/route_helpers'
+require_relative 'translator/path'
+require_relative 'route'
 
 module RouteTranslator
   module Translator

--- a/lib/route_translator/translator/path.rb
+++ b/lib/route_translator/translator/path.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'route_translator/translator/path/segment'
+require_relative 'path/segment'
 
 module RouteTranslator
   module Translator


### PR DESCRIPTION
`require_relative` is preferred over `require` for files within the same project because it uses paths relative to the current file, making code more portable and less dependent on the load path.

This change updates internal requires to use `require_relative` for consistency, performance, and improved portability.

Refs:
- rubocop/rubocop#8748