### PR TITLE
Fix RuboCop exclusions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,8 +12,10 @@ AllCops:
   DisplayStyleGuide: true
   ExtraDetails: true
   Exclude:
-    - 'gemfiles/**/*'
-    - 'vendor/bundle/**/*'
+    - .git/**/*
+    - gemfiles/**/*
+    - tmp/**/*
+    - vendor/**/*
 
 Layout/HashAlignment:
   EnforcedColonStyle: table

--- a/Appraisals
+++ b/Appraisals
@@ -2,10 +2,12 @@
 
 appraise 'rails-6.1' do
   gem 'rails', '~> 6.1.0'
+  gem 'concurrent-ruby', '< 1.3.5' # ref: rails/rails#54260
 end
 
 appraise 'rails-7.0' do
   gem 'rails', '~> 7.0.0'
+  gem 'concurrent-ruby', '< 1.3.5' # ref: rails/rails#54260
 end
 
 appraise 'rails-7.1' do

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -7,13 +7,14 @@ gem "byebug"
 gem "minitest"
 gem "rails", "~> 6.1.0"
 gem "rake"
-gem "rubocop"
-gem "rubocop-minitest"
-gem "rubocop-packaging"
-gem "rubocop-performance"
-gem "rubocop-rails"
-gem "rubocop-rake"
-gem "simplecov"
-gem "simplecov-lcov"
+gem "rubocop", require: false
+gem "rubocop-minitest", require: false
+gem "rubocop-packaging", require: false
+gem "rubocop-performance", require: false
+gem "rubocop-rails", require: false
+gem "rubocop-rake", require: false
+gem "simplecov", require: false
+gem "simplecov-lcov", require: false
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -7,13 +7,14 @@ gem "byebug"
 gem "minitest"
 gem "rails", "~> 7.0.0"
 gem "rake"
-gem "rubocop"
-gem "rubocop-minitest"
-gem "rubocop-packaging"
-gem "rubocop-performance"
-gem "rubocop-rails"
-gem "rubocop-rake"
-gem "simplecov"
-gem "simplecov-lcov"
+gem "rubocop", require: false
+gem "rubocop-minitest", require: false
+gem "rubocop-packaging", require: false
+gem "rubocop-performance", require: false
+gem "rubocop-rails", require: false
+gem "rubocop-rake", require: false
+gem "simplecov", require: false
+gem "simplecov-lcov", require: false
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -7,13 +7,13 @@ gem "byebug"
 gem "minitest"
 gem "rails", "~> 7.1.0"
 gem "rake"
-gem "rubocop"
-gem "rubocop-minitest"
-gem "rubocop-packaging"
-gem "rubocop-performance"
-gem "rubocop-rails"
-gem "rubocop-rake"
-gem "simplecov"
-gem "simplecov-lcov"
+gem "rubocop", require: false
+gem "rubocop-minitest", require: false
+gem "rubocop-packaging", require: false
+gem "rubocop-performance", require: false
+gem "rubocop-rails", require: false
+gem "rubocop-rake", require: false
+gem "simplecov", require: false
+gem "simplecov-lcov", require: false
 
 gemspec path: "../"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -7,13 +7,13 @@ gem "byebug"
 gem "minitest"
 gem "rails", "~> 7.2.0"
 gem "rake"
-gem "rubocop"
-gem "rubocop-minitest"
-gem "rubocop-packaging"
-gem "rubocop-performance"
-gem "rubocop-rails"
-gem "rubocop-rake"
-gem "simplecov"
-gem "simplecov-lcov"
+gem "rubocop", require: false
+gem "rubocop-minitest", require: false
+gem "rubocop-packaging", require: false
+gem "rubocop-performance", require: false
+gem "rubocop-rails", require: false
+gem "rubocop-rake", require: false
+gem "simplecov", require: false
+gem "simplecov-lcov", require: false
 
 gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -7,13 +7,13 @@ gem "byebug"
 gem "minitest"
 gem "rails", "~> 8.0.0"
 gem "rake"
-gem "rubocop"
-gem "rubocop-minitest"
-gem "rubocop-packaging"
-gem "rubocop-performance"
-gem "rubocop-rails"
-gem "rubocop-rake"
-gem "simplecov"
-gem "simplecov-lcov"
+gem "rubocop", require: false
+gem "rubocop-minitest", require: false
+gem "rubocop-packaging", require: false
+gem "rubocop-performance", require: false
+gem "rubocop-rails", require: false
+gem "rubocop-rake", require: false
+gem "simplecov", require: false
+gem "simplecov-lcov", require: false
 
 gemspec path: "../"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -7,13 +7,13 @@ gem "byebug"
 gem "minitest"
 gem "rails", git: "https://github.com/rails/rails.git", branch: "main"
 gem "rake"
-gem "rubocop"
-gem "rubocop-minitest"
-gem "rubocop-packaging"
-gem "rubocop-performance"
-gem "rubocop-rails"
-gem "rubocop-rake"
-gem "simplecov"
-gem "simplecov-lcov"
+gem "rubocop", require: false
+gem "rubocop-minitest", require: false
+gem "rubocop-packaging", require: false
+gem "rubocop-performance", require: false
+gem "rubocop-rails", require: false
+gem "rubocop-rake", require: false
+gem "simplecov", require: false
+gem "simplecov-lcov", require: false
 
 gemspec path: "../"


### PR DESCRIPTION
They do not inherit from base when `AllCops` rule is being configured, this will speed up execution