### PR TITLE
Fix test by reloading routes after config reset

### DIFF
--- a/test/integration/generated_path_test.rb
+++ b/test/integration/generated_path_test.rb
@@ -12,6 +12,7 @@ class GeneratedPathTest < ActionDispatch::IntegrationTest
 
   def teardown
     teardown_config
+    Rails.application.reload_routes!
   end
 
   def test_path_generated

--- a/test/integration/locale_path_segment_test.rb
+++ b/test/integration/locale_path_segment_test.rb
@@ -6,7 +6,7 @@ class LocaleSegmentProcTest < ActionDispatch::IntegrationTest
   include RouteTranslator::ConfigurationHelper
 
   def teardown
-    config_locale_segment_proc false
+    teardown_config
     Rails.application.reload_routes!
   end
 

--- a/test/integration/thread_safety_test.rb
+++ b/test/integration/thread_safety_test.rb
@@ -5,14 +5,6 @@ require 'test_helper'
 class ThreadSafetyTest < ActionDispatch::IntegrationTest
   include RouteTranslator::ConfigurationHelper
 
-  def setup
-    setup_config
-  end
-
-  def teardown
-    teardown_config
-  end
-
   def test_i18n_locale_thread_safe
     get '/es/dummy'
 


### PR DESCRIPTION
Since Rails 8.0, route loading timing changed, causing order-dependent
test failures when routes are dynamically changed between specs.

By calling `Rails.application.reload_routes!` we ensure routes are
always in sync with the current configuration, avoiding test pollution
and fixing random failures.

This is not being added to the global `teardown_config` for performance
reasons.

Additionally, remove setup and teardown config where config is not
changed

Fix https://github.com/enriclluelles/route_translator/issues/321

Refs:
- https://github.com/rails/rails/commit/9f80efc791
- https://github.com/rails/rails/pull/52353