### PR TITLE
Ensure `@localized` is always reset after yield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master / unreleased
+
+* [BUGFIX] Ensure `@localized` is always reset after yield ([#333](https://github.com/enriclluelles/route_translator/issues/333))
+
 ## 15.0.0 / 2025-06-12
 
 * [FEATURE] Drop Ruby < 3.1 support

--- a/lib/route_translator/extensions/mapper.rb
+++ b/lib/route_translator/extensions/mapper.rb
@@ -8,6 +8,7 @@ module ActionDispatch
       def localized
         @localized = true
         yield
+      ensure
         @localized = false
       end
 

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -734,6 +734,22 @@ class TranslateRoutesTest < ActionController::TestCase
 
     assert_not_respond_to @routes.url_helpers, :products_ru_path
   end
+
+  def test_raise_in_localized_block
+    draw_routes do
+      begin
+        localized do
+          raise StandardError, 'Error'
+        end
+      rescue StandardError
+        nil
+      end
+
+      resources :products
+    end
+
+    assert_not_respond_to @routes.url_helpers, :products_ru_path
+  end
 end
 
 class ProductsControllerTest < ActionController::TestCase


### PR DESCRIPTION
Guarantee that `@localized` is set back to `false` even if an exception occurs during the block execution, preventing inconsistent state.

Fixes #333