### PR TITLE
Enforce locale segment to use pt-br locale

### DIFF
--- a/lib/route_translator/translator/path.rb
+++ b/lib/route_translator/translator/path.rb
@@ -26,10 +26,8 @@ module RouteTranslator
         end
 
         def locale_segment(locale)
-          if RouteTranslator.config.locale_segment_proc
-            locale_segment_proc = RouteTranslator.config.locale_segment_proc
-
-            locale_segment_proc.to_proc.call(locale)
+          if locale.to_s.downcase == "pt"
+            "pt-br"
           else
             locale.to_s.downcase
           end
@@ -52,6 +50,10 @@ module RouteTranslator
         end
 
         joined_segments = translated_segments.join('/')
+
+        if locale_param_present?(new_path) && locale.to_s.downcase == "pt"
+          joined_segments.gsub!(":#{RouteTranslator.locale_param_key}", "pt-br")
+        end
 
         "/#{joined_segments}#{final_optional_segments}".gsub(%r{\/\(\/}, '(/')
       end


### PR DESCRIPTION
To support internal links that point to pt-br without changing the intrinsic value of `I18n.locale`, enforce pt-br locale segment in all localized paths.