### PR TITLE
Relax minitest dependency to allow version 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 gem 'appraisal2'
 gem 'byebug'
-gem 'minitest', '~> 5.27' # TODO: relax when the minimum required Rails version will include rails/rails@99395e1ea401acbc23d4f6b2a8657cdb82f921bd
+gem 'minitest'
 gem 'rails'
 gem 'rake'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,7 +21,6 @@ SimpleCov.start 'rails' do
 end
 
 require 'minitest/autorun'
-require 'minitest/mock'
 
 require 'i18n'
 


### PR DESCRIPTION
minitest 5.x is enforced at Rails 7.2 level.

Additionally, remove minitest-mock which does not appear to be used. Last used in 2fb75a2

Ref: rails/rails#56442