### PR TITLE
Drop an ineffective helper_names lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * [ENHANCEMENT] Speed up drawing localized routes. `Translator.translate_name` asked the route set for `named_routes.names` (a freshly allocated array of every name defined so far) and scanned it linearly, once per route per locale. It now uses the `NamedRouteCollection#key?` hash lookup.
+* [ENHANCEMENT] Speed up drawing localized routes. `Translator::RouteHelpers.add` fetched `named_route_collection.helper_names` on every route, allocating an array of every helper defined so far and scanning it, to guard a `push` that could not take effect. `helper_names` builds a fresh array on every call, so the push was discarded, and it returns Strings while the pushed value is a Symbol, so the `include?` guard never matched either. Removing both leaves behavior unchanged.
 
 ## 16.0.1 / 2026-04-05
 

--- a/lib/route_translator/translator/route_helpers.rb
+++ b/lib/route_translator/translator/route_helpers.rb
@@ -15,13 +15,9 @@ module RouteTranslator
       #   I18n.locale = :fr
       #   people_path -> people_fr_path
       def add(old_name, named_route_collection)
-        helper_list = named_route_collection.helper_names
-
         %w[path url].each do |suffix|
           helper_container = named_route_collection.send(:"#{suffix}_helpers_module")
           new_helper_name = :"#{old_name}_#{suffix}"
-
-          helper_list.push(new_helper_name) unless helper_list.include?(new_helper_name)
 
           helper_container.__send__(:define_method, new_helper_name) do |*args|
             __send__(Translator.route_name_for(args, old_name, suffix, self), *args)

--- a/test/helper_names_lookup_test.rb
+++ b/test/helper_names_lookup_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# `NamedRouteCollection#helper_names` builds a fresh array of every helper defined
+# so far on every call. Calling it while drawing routes makes the cost of drawing
+# grow with the size of the route set.
+#
+# This is deliberately not a timing test. It asserts the shape of the work, which
+# is stable on a busy CI machine where wall-clock is not.
+class HelperNamesLookupTest < ActionController::TestCase
+  include RouteTranslator::ConfigurationHelper
+  include RouteTranslator::I18nHelper
+  include RouteTranslator::RoutesHelper
+
+  def setup
+    setup_config
+    setup_i18n
+    config hide_locale: true
+    @routes = ActionDispatch::Routing::RouteSet.new
+  end
+
+  def teardown
+    teardown_i18n
+    teardown_config
+  end
+
+  # Counts around `@routes.draw` rather than the `draw_routes` helper, which also
+  # installs the route helpers into ActionController and friends. That is not part
+  # of drawing, and counting it would make this assert more than it intends.
+  def test_does_not_build_the_helper_name_list_while_drawing_routes
+    calls = count_calls_to(ActionDispatch::Routing::RouteSet::NamedRouteCollection, :helper_names) do
+      @routes.draw do
+        localized do
+          20.times { |i| get "segment#{i}", to: 'people#index', as: :"thing#{i}" }
+        end
+      end
+    end
+
+    assert_equal 0, calls, "expected no calls to NamedRouteCollection#helper_names, got #{calls}"
+  end
+
+  # The push that used to happen here never took effect, so removing it must leave
+  # the collection's view of its helpers exactly as it was.
+  def test_helper_names_still_reports_the_routes_rails_registered
+    draw_routes do
+      localized do
+        get 'people', to: 'people#index', as: :people
+      end
+    end
+
+    helper_names = @routes.named_routes.helper_names
+
+    assert_includes helper_names, 'people_en_path'
+    assert_includes helper_names, 'people_es_url'
+  end
+
+  private
+
+  def count_calls_to(klass, method)
+    count = 0
+    original = klass.instance_method(method)
+
+    klass.define_method(method) do |*args, &blk|
+      count += 1
+      original.bind_call(self, *args, &blk)
+    end
+
+    yield
+    count
+  ensure
+    klass.define_method(method, original)
+  end
+end


### PR DESCRIPTION
While trying to optimize the load time of our Rails 8.1 application using Claude Code, it noticed the following issue which in our codebase was able to greatly speedup the load times of our routes.

The description generated by Claude kept below as is. 

It was calling the `helper_methods` function and adding items to this list, but each time you call this method it generates a new list, making this code basically a no-op. https://github.com/rails/rails/blob/fa8f0812160665bff083a089d2bb2fc1817ea03e/actionpack/lib/action_dispatch/routing/route_set.rb#L100

Together with #360 they were able to improve our application start time by about 15%

--- 

`Translator::RouteHelpers.add` fetched
`named_route_collection.helper_names` and pushed the helper it was about to define onto the result unless already present.

Neither half of that could take effect.
`NamedRouteCollection#helper_names` builds a fresh array on every call, so the push was made to a value that is discarded as soon as the method returns. It also returns Strings while the pushed value is a Symbol, so the `include?` guard never matched and the push always ran. Removing both leaves behaviour unchanged.

What it did cost was an allocation of every helper defined so far plus a linear scan of it, once per route, so drawing localized routes got slower as the route set grew.

Measured with 40 locales, drawing N localized routes:

| routes | generated | before | after |
| -----: | --------: | -----: | ----: |
| 50 | 2,000 | 143ms | 137ms |
| 200 | 8,000 | 970ms | 689ms |
| 800 | 32,000 | 16,979ms | 6,263ms |

Cost per generated route still climbs with the size of the route set, 2.9x across that range rather than 7.4x, because
`Translator.translate_name` performs a second lookup of the same shape: it is handed `named_routes.names`, which likewise allocates an array of every route name defined so far. That one is left alone here.

Route sets drawn before and after this change are identical, including the collection's own `helper_names`, which is asserted directly. A second test asserts the shape of the work rather than its duration, counting calls to `helper_names`, so the lookup cannot come back unnoticed and CI does not depend on a timing threshold.


---

Test script to check out the performance improvements:
```ruby
# frozen_string_literal: true
#
#   bundle exec ruby bench_scaling.rb
#
# Quadratic behaviour shows up as time-per-route rising with N.

ENV['RAILS_ENV'] = 'benchmark' # keeps RouteHelpers' test hooks out

require 'i18n'
require 'rails'
require 'action_controller/railtie'
require 'route_translator'

RouteTranslator.deprecator.silenced = true

LOCALES = %i[
  en es fr de it nl pt sv da no fi pl cs sk hu ro bg el tr ru
  ja ko zh ar he hi th vi id ms uk lt lv et sl hr sr bs mk sq
].freeze

# No translations are defined, so paths fall back to the
# untranslated segment. This measures routing, not I18n.
I18n.available_locales = LOCALES
I18n.default_locale = :en
I18n.backend = I18n::Backend::Simple.new
I18n.enforce_available_locales = false

RouteTranslator.config do |c|
  c.force_locale = false
  c.hide_locale  = true
end

def build(route_count)
  set = ActionDispatch::Routing::RouteSet.new
  t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
  set.draw do
    localized do
      route_count.times do |i|
        get "/segment#{i}", to: "things#show#{i}", as: :"thing#{i}"
      end
    end
  end
  ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0) * 1000
  [ms, set.routes.size]
end

puts "locales: #{LOCALES.size}"
puts format('%8s %10s %9s %10s',
            'routes', 'generated', 'time', 'us/route')

first = nil
[50, 100, 200, 400, 800].each do |n|
  ms, generated = build(n)
  per = (ms * 1000) / generated
  first ||= per
  puts format('%8d %10d %7.0fms %8.1fus (%.1fx)',
              n, generated, ms, per, per / first)
end
```