### PR TITLE
Document ReDoS assumption for host_locales patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,11 @@ This is to avoid odd behaviour brought about by route conflicts and because `hos
 
 NOTE: locale from parameters has priority over the one from hosts.
 
+**Security note:** Host patterns are treated as trusted configuration.
+Never pass user input into `host_locales` keys — the wildcard `*` is
+translated to a non-greedy `.*?` regex, which can expose your application
+to ReDoS if an attacker controls the pattern.
+
 ### Translations for similar routes with different namespaces
 
 If you have routes that (partially) share names in one locale, but must be translated differently in another locale, for example:

--- a/lib/route_translator/host.rb
+++ b/lib/route_translator/host.rb
@@ -9,6 +9,10 @@ module RouteTranslator
         @lambdas ||= {}
       end
 
+      # Host patterns come from configuration, not user input.
+      # Treating them as trusted avoids a ReDoS vector — the
+      # gsub introduces non-greedy `.*?` wildcards, which are
+      # safe against backtracking only under that assumption.
       def regex_for(host_string)
         escaped = Regexp.escape(host_string).gsub(/\\\*|\\\./, '\\*' => '.*?', '\\.' => '\.?')
         Regexp.new("^#{escaped}$", Regexp::IGNORECASE)


### PR DESCRIPTION
Host patterns are trusted configuration, not user input. The wildcard `*` is translated to a non-greedy `.*?` regex, which is safe against backtracking only under that assumption. Document this to guide safe usage.