### PR TITLE
Fix test failure from double engine mount in routes.rb

### DIFF
--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  mount Blorgh::Engine, at: '/blorgh'
-
   localized do
     get 'dummy',  to: 'dummy#dummy'
     get 'show',   to: 'dummy#show'
@@ -19,15 +17,11 @@ Rails.application.routes.draw do
     namespace :account do
       root to: 'foo#account_root'
     end
-
-    mount Blorgh::Engine, at: '/blorgh'
   end
 
   get 'unlocalized', to: 'dummy#unlocalized'
   get 'partial_caching', to: 'dummy#partial_caching'
   get 'native', to: 'dummy#native'
-  get 'engine_es', to: 'dummy#engine_es'
-  get 'engine', to: 'dummy#engine'
 
   root to: 'dummy#dummy'
 end

--- a/test/integration/engine_test.rb
+++ b/test/integration/engine_test.rb
@@ -2,8 +2,20 @@
 
 require 'test_helper'
 
-class RoutingTest < ActionDispatch::IntegrationTest
+class EngineTest < ActionDispatch::IntegrationTest
+  def teardown
+    Rails.application.reload_routes!
+  end
+
   def test_with_engine_inside_localized_block
+    Rails.application.routes.draw do
+      localized do
+        mount Blorgh::Engine, at: '/blorgh'
+      end
+
+      get 'engine_es', to: 'dummy#engine_es'
+    end
+
     get '/engine_es'
 
     assert_response :success
@@ -11,6 +23,12 @@ class RoutingTest < ActionDispatch::IntegrationTest
   end
 
   def test_with_engine_outside_localized_block
+    Rails.application.routes.draw do
+      mount Blorgh::Engine, at: '/blorgh'
+
+      get 'engine', to: 'dummy#engine'
+    end
+
     get '/engine'
 
     assert_response :success


### PR DESCRIPTION
Mount Blorgh::Engine twice at the same location in the dummy app routes caused a route name collision when routes were lazily reloaded, triggering a 500 error.

Remove both static engine mounts from routes.rb and rewrite engine tests to draw routes dynamically per-test, with `reload_routes!` in teardown to restore the original state.

This fix also reveals a pre-existing `assert_select` failure in `test_path_translated_while_generate_unlocalized_routes` that was previously masqueraded by the 500 crash. The `show_path` helper does not resolve to the locale-specific path when `generate_unlocalized_routes` is true and routes are lazily loaded in isolation. That issue is unrelated to #346.

Fixes #346