### PR TITLE
Centralize available locale resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 17.0.0 / 2026-08-04
+
+* [BUGFIX] POTENTIAL BREAKING CHANGE: Locale validation now respects `RouteTranslator.available_locales`, so request parameters and hosts cannot select locales excluded by `config.available_locales`. Configured locales are sanitized against `I18n.available_locales`, and the default locale is always included last.
+* [ENHANCEMENT] POTENTIAL BREAKING CHANGE: `RouteTranslator.available_locales` now returns a memoized, frozen `Set<Symbol>` instead of a newly allocated array. The cache is cleared by block-form configuration and `reset_config`.
+
 ## 16.2.0 / 2026-07-29
 
 * [ENHANCEMENT] Short-circuit host locale detection by checking `available_locales.include?` before the regex match, avoiding unnecessary regex compilation and matching for unavailable locales.

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ end
 
 | Option | Description | Default |
 | ------ | ----------- |-------- |
-| `available_locales` | Limit the locales for which URLs should be generated for. Accepts an array of strings or symbols. When empty, translations will be generated for all `I18n.available_locales` | `[]` |
+| `available_locales` | Limit the locales for which URLs should be generated for. Accepts an array of strings or symbols. Values are sanitized against `I18n.available_locales`, so the final route locales are always a subset of `I18n.available_locales`, and the default locale cannot be excluded from generated routes. When empty, translations will be generated for all `I18n.available_locales` | `[]` |
 | `disable_fallback` | Create routes only for locales that have translations. For example, if we have `/examples` and a translation is not provided for `es`, the route helper of `examples_es` will not be created. Useful when one uses this with a locale route constraint, so non-`es` routes can return a `404` on a Spanish website | `false` |
 | `force_locale` |  Force the locale to be added to all generated route paths, even for the default locale |  `false` |
 | `generate_unlocalized_routes` | Add translated routes without deleting original unlocalized versions. **Note:** Autosets `force_locale` to `true` | `false` |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,26 @@ See the [CHANGELOG.md](./CHANGELOG.md) for detailed information about what has c
 
 This guide is useful to figure out what you need to do between breaking changes.
 
+## 16.2.0 to 17.0.0
+
+`config.available_locales` now controls locale selection from request
+parameters and hosts, not only route generation. Add every locale that must
+be selectable to this configuration; values absent from
+`I18n.available_locales` are ignored, while the default locale remains
+included.
+
+`RouteTranslator.available_locales` now returns a cached, frozen
+`Set<Symbol>` rather than a newly allocated array. Update callers that mutate
+the result to work with a copy instead. When changing locale configuration at
+runtime, use block-form `RouteTranslator.config` or call `reset_config` to
+rebuild the cache.
+
+## 15.2.0 to 16.0.0
+
+RouteTranslator 16 requires Ruby 3.2 or later and Rails 7.2 or later. Upgrade
+both dependencies before upgrading the gem, or remain on RouteTranslator 15.2.0
+if your application must support older versions.
+
 ## 14.0.0 to 15.0.0
 
 Route helpers now respect locale parameters (e.g., `posts_path(locale: "en")`) regardless

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -52,7 +52,10 @@ module RouteTranslator
       @config[option] ||= value
     end
 
-    yield @config if block_given?
+    if block_given?
+      yield @config
+      @available_locales = nil
+    end
 
     resolve_host_locale_config_conflicts if @config.host_locales.present?
     check_deprecations
@@ -65,20 +68,32 @@ module RouteTranslator
   # @return [Configuration] the reset configuration
   def reset_config
     @config = nil
+    @available_locales = nil
 
     config
   end
 
   # Returns the locales for which translated routes are generated.
   #
-  # @return [Array<Symbol>] the configured locales, or all I18n locales
+  # @return [Set<Symbol>] the configured locales, or all I18n locales
   def available_locales
-    locales = config.available_locales
+    @available_locales ||= begin
+      i18n_locales = I18n.available_locales.to_set(&:to_sym)
+      configured_locales = config.available_locales
 
-    if locales.empty?
-      I18n.available_locales.dup
-    else
-      locales.map(&:to_sym)
+      locales = if configured_locales.empty?
+                  i18n_locales
+                else
+                  configured_locales.to_set(&:to_sym) & i18n_locales
+                end
+
+      default_locale = I18n.default_locale.to_sym
+
+      # Make sure the default locale is translated in last place to avoid
+      # problems with wildcards when the default locale is omitted in paths.
+      locales.delete(default_locale)
+      locales.add(default_locale)
+      locales.freeze
     end
   end
 
@@ -95,7 +110,7 @@ module RouteTranslator
   # @return [Symbol, nil] the requested available locale
   def locale_from_params(params)
     locale = params[config.locale_param_key]&.to_sym
-    locale if I18n.available_locales.include?(locale)
+    locale if available_locales.include?(locale)
   end
 
   # Extracts an available locale from request parameters or its host.

--- a/lib/route_translator/extensions/legacy/mapper.rb
+++ b/lib/route_translator/extensions/legacy/mapper.rb
@@ -50,7 +50,7 @@ module ActionDispatch
       def define_generate_prefix(app, name)
         return super unless @localized
 
-        RouteTranslator::Translator.available_locales.each do |locale|
+        RouteTranslator.available_locales.each do |locale|
           super(app, "#{name}_#{locale.to_s.underscore}")
         end
       end

--- a/lib/route_translator/extensions/mapper.rb
+++ b/lib/route_translator/extensions/mapper.rb
@@ -45,7 +45,7 @@ module ActionDispatch
       def define_generate_prefix(app, name)
         return super unless @localized
 
-        RouteTranslator::Translator.available_locales.each do |locale|
+        RouteTranslator.available_locales.each do |locale|
           super(app, "#{name}_#{locale.to_s.underscore}")
         end
       end

--- a/lib/route_translator/host.rb
+++ b/lib/route_translator/host.rb
@@ -22,10 +22,8 @@ module RouteTranslator
     module_function
 
     def locale_from_host(host)
-      available_locales = I18n.available_locales
-
       RouteTranslator.config.host_locales.find do |pattern, locale|
-        available_locales.include?(locale&.to_sym) && host&.match?(regex_for(pattern))
+        RouteTranslator.available_locales.include?(locale&.to_sym) && host&.match?(regex_for(pattern))
       end&.last&.to_sym
     end
 

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -51,19 +51,10 @@ module RouteTranslator
 
     module_function
 
-    def available_locales
-      locales = RouteTranslator.available_locales
-      # Make sure the default locale is translated in last place to avoid
-      # problems with wildcards when default locale is omitted in paths. The
-      # default routes will catch all paths like wildcard if it is translated first.
-      locales.delete I18n.default_locale
-      locales.push I18n.default_locale
-    end
-
     def translations_for(route)
       RouteTranslator::Translator::RouteHelpers.add route.name, route.route_set.named_routes
 
-      available_locales.each do |locale|
+      RouteTranslator.available_locales.each do |locale|
         translated_path = translate_path(route.path, locale, route.scope)
         next unless translated_path
 

--- a/lib/route_translator/version.rb
+++ b/lib/route_translator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RouteTranslator
-  VERSION = '16.2.0'
+  VERSION = '17.0.0'
 end

--- a/test/host_test.rb
+++ b/test/host_test.rb
@@ -99,4 +99,75 @@ class TestHostsFromLocale < Minitest::Test
       assert_equal :en, RouteTranslator::Host.locale_from_host(domain)
     end
   end
+
+  def test_available_locales_are_a_cached_frozen_set_of_symbols
+    I18n.available_locales = %i[es en]
+    config available_locales: %w[es en]
+
+    locales = RouteTranslator.available_locales
+
+    assert_instance_of Set, locales
+    assert_equal Set[:es, :en], locales
+    assert_predicate locales, :frozen?
+    assert_same locales, RouteTranslator.available_locales
+  end
+
+  def test_available_locales_are_sanitized_against_i18n_available_locales
+    I18n.available_locales = %i[es en]
+    config available_locales: %i[en fr]
+
+    assert_equal Set[:en], RouteTranslator.available_locales
+    assert_nil RouteTranslator.locale_from_params({ locale: 'fr' })
+  end
+
+  def test_default_locale_is_always_last_available_locale
+    I18n.available_locales = %i[es en it]
+    I18n.default_locale = :en
+    config available_locales: %i[en it]
+
+    assert_equal %i[it en], RouteTranslator.available_locales.to_a
+
+    config available_locales: %i[it]
+
+    assert_equal %i[it en], RouteTranslator.available_locales.to_a
+  end
+
+  def test_available_locales_cache_is_invalidated_by_config_block
+    locales = RouteTranslator.available_locales
+
+    config available_locales: %i[en]
+
+    refute_same locales, RouteTranslator.available_locales # rubocop:disable Rails/RefuteMethods
+    assert_equal Set[:en], RouteTranslator.available_locales
+  end
+
+  def test_available_locales_cache_is_invalidated_by_reset_config
+    locales = RouteTranslator.available_locales
+
+    RouteTranslator.reset_config
+
+    refute_same locales, RouteTranslator.available_locales # rubocop:disable Rails/RefuteMethods
+  end
+
+  def test_available_locales_cache_is_preserved_when_config_is_read
+    locales = RouteTranslator.available_locales
+
+    RouteTranslator.config
+
+    assert_same locales, RouteTranslator.available_locales
+  end
+
+  def test_locale_from_params_respects_available_locales_config
+    config available_locales: %i[en]
+
+    assert_nil RouteTranslator.locale_from_params({ locale: 'es' })
+    assert_equal :en, RouteTranslator.locale_from_params({ locale: 'en' })
+  end
+
+  def test_locale_from_host_respects_available_locales_config
+    config available_locales: %i[en]
+
+    assert_nil RouteTranslator::Host.locale_from_host('www.something.es')
+    assert_equal :en, RouteTranslator::Host.locale_from_host('www.something.com')
+  end
 end

--- a/test/support/configuration_helper.rb
+++ b/test/support/configuration_helper.rb
@@ -8,8 +8,10 @@ module RouteTranslator
     alias teardown_config reset_config
 
     def config(**options)
-      options.each do |option, value|
-        RouteTranslator.config[option] = value
+      RouteTranslator.config do |configuration|
+        options.each do |option, value|
+          configuration[option] = value
+        end
       end
     end
   end


### PR DESCRIPTION
Use one cached locale set for route generation, request parameters, and host matching so configured exclusions apply consistently.

Normalize configured values to symbols, discard locales unavailable to I18n, and keep the default locale last so unprefixed wildcard routes cannot shadow localized routes. Freeze the Set for constant-time lookup and invalidate it after block configuration or reset.

Document the breaking behavior and release it as version 17.0.0.